### PR TITLE
Build and deploy Sphinx documentation to GitHub Pages

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -64,6 +64,7 @@ jobs:
           source install/setup.bash
           export PATH=$(dirname $(find / -iname sphinx-build -print -quit)):$PATH
           cd src/gisnav/docs/ && make html
+          cd _build/html && touch .nojekyll
 
       - name: Setup Pages
         uses: actions/configure-pages@v1
@@ -78,6 +79,7 @@ jobs:
 
   deploy:
     needs: build
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
 
     permissions:
       contents: read

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -62,3 +62,26 @@ jobs:
           source install/setup.bash
           export PATH=$(dirname $(find / -iname sphinx-build -print -quit)):$PATH
           cd src/gisnav/docs/ && make html
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: colcon_ws/src/gisnav/docs/_build/html
+
+  deploy:
+    needs: build
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@main

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -1,0 +1,64 @@
+name: Build Sphinx Documentation
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+  # Allows running manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    container: px4io/px4-dev-ros2-foxy
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Install node
+        run: |
+          curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+          sudo apt-get install -y nodejs
+
+      - name: Create colcon workspace
+        run: mkdir -p colcon_ws/src
+
+      - name: Setup PX4-ROS 2 bridge
+        uses: actions/checkout@v3
+        with:
+          repository: PX4/px4_ros_com
+          path: colcon_ws/src/px4_ros_com
+
+      - name: Checkout PX4 messages
+        uses: actions/checkout@v3
+        with:
+          repository: PX4/px4_msgs
+          path: colcon_ws/src/px4_msgs
+
+      - name: Build colcon workspace
+        run: |
+          cd colcon_ws/src/px4_ros_com/scripts
+          ./build_ros2_workspace.bash
+
+      - name: Checkout GISNav
+        uses: actions/checkout@v3
+        with:
+          path: colcon_ws/src/gisnav
+
+      - name: Install GISNav
+        run: |
+          cd colcon_ws/src/gisnav
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          cd ../..
+          colcon build --packages-select gisnav
+
+      - name: Build Sphinx docs
+        run: |
+          cd colcon_ws
+          source /opt/ros/foxy/setup.bash
+          source install/setup.bash
+          export PATH=$(dirname $(find / -iname sphinx-build -print -quit)):$PATH
+          cd src/gisnav/docs/ && make html

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: colcon_ws/src/gisnav/docs/_build/html
+          path: 'colcon_ws/src/gisnav/docs/_build/html/'
 
   deploy:
     needs: build
@@ -84,6 +84,8 @@ jobs:
 
     runs-on: ubuntu-20.04
     steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@main

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -65,6 +65,12 @@ jobs:
           export PATH=$(dirname $(find / -iname sphinx-build -print -quit)):$PATH
           cd src/gisnav/docs/ && make html
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
+
+      - name: Make Upload Pages Artifact step work with containers
+        run: mkdir -p ${{runner.temp}}
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v1
         with:
@@ -84,8 +90,6 @@ jobs:
 
     runs-on: ubuntu-20.04
     steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v1
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@main

--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -46,10 +46,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: colcon_ws/src/gisnav
+          submodules: 'true'
 
       - name: Install GISNav
         run: |
           cd colcon_ws/src/gisnav
+          git submodule update --init
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
           cd ../..


### PR DESCRIPTION
- Adds a workflow to automatically build and deploy the Sphinx documentation to GitHub Pages.
- Removes cached weights folder that should not be there (already included in .gitignore)