### PR TITLE
Add symbolic link to make upload pages artifact work with container

### DIFF
--- a/.github/workflows/build-sphinx.yml
+++ b/.github/workflows/build-sphinx.yml
@@ -70,7 +70,10 @@ jobs:
         uses: actions/configure-pages@v1
 
       - name: Make Upload Pages Artifact step work with containers
-        run: mkdir -p ${{runner.temp}}
+        run: |
+          mkdir -p ${{runner.temp}}
+          mkdir -p /__w/_temp
+          ln -s ${{runner.temp}}/artifact.tar /__w/_temp/artifact.tar
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
Artifact was not being uploaded in previous workflow version because of: "Warning: No files were found with the provided path: /__w/_temp/artifact.tar. No artifacts will be uploaded." This PR adds a symbolic link to fix that issue (seems to be an issue when using a container).