### PR TITLE
Require docutils>=0.17

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 Sphinx==4.3.2
 pydata-sphinx-theme
 autodocsumm==0.2.7
+docutils>=0.17
 myst_parser==0.16.1
 pygments==2.11.2  # make Sphinx highlighting work
 pytest


### PR DESCRIPTION
Require docutils>=0.17 to make myst_parser work and include the README markdown on the Get Started page of Sphinx docs.