### PR TITLE
Add ROS 2 integration tests to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,14 +48,32 @@ jobs:
           path: colcon_ws/src/gisnav
           submodules: 'true'
 
+      - name: Get LoFTR weights
+        run: |
+          pip install gdown
+          cd colcon_ws/src/gisnav
+          mkdir weights && cd "$_"
+          gdown https://drive.google.com/uc?id=1M-VD35-qdB5Iw-AtbDBCKC7hPolFW9UY
+
       - name: Install GISNav
         run: |
-          cd colcon_ws/src/gisnav
+          cd colcon_ws
+          rosdep update
+          rosdep install --from-paths src --ignore-src -y --rosdistro=foxy
+          cd src/gisnav
           git submodule update --init
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
           cd ../..
           colcon build --packages-select gisnav
+
+      - name: Run ROS 2 integration tests
+        run: |
+          cd colcon_ws
+          source /opt/ros/foxy/setup.bash
+          source install/setup.bash
+          python3 -m coverage run --branch --include */site-packages/gisnav/* src/gisnav/test/test_mock_gps_node.py
+          python3 -m coverage report
 
       - name: Build Sphinx docs
         run: |

--- a/README.md
+++ b/README.md
@@ -61,9 +61,12 @@ cd ~/px4_ros_com_ros2/src/gisnav && git submodule update LoFTR
 
 Download the **dual-softmax** (_ds suffix) outdoor weights as described in the 
 [LoFTR repo](https://github.com/zju3dv/LoFTR). Extract the `outdoor_ds.ckpt` from the .zip package and copy it into a 
-new `weights` folder:
+new `weights` folder. You can use `gdown` to do everything from the command line:
 ```bash
-mkdir weights && cp ~/Downloads/outdoor_ds.ckpt ./weights
+pip install gdown
+cd ~/px4_ros_com_ros2/src/gisnav
+mkdir weights && cd "$_"
+gdown https://drive.google.com/uc?id=1M-VD35-qdB5Iw-AtbDBCKC7hPolFW9UY
 ```
 
 ## Configure WMS endpoint

--- a/gisnav/__main__.py
+++ b/gisnav/__main__.py
@@ -22,6 +22,8 @@ def main(args=None):
         pr.enable()
     else:
         pr = None
+
+    mock_gps_node = None
     try:
         rclpy.init(args=args)
         mock_gps_node = MockGPSNode('mock_gps_node', get_package_share_directory(package_name))
@@ -36,9 +38,10 @@ def main(args=None):
             ps.print_stats(40)
             print(s.getvalue())
     finally:
-        mock_gps_node.destroy_timers()
-        mock_gps_node.terminate_pools()
-        mock_gps_node.destroy_node()
+        if mock_gps_node is not None:
+            mock_gps_node.destroy_timers()
+            mock_gps_node.terminate_pools()
+            mock_gps_node.destroy_node()
         rclpy.shutdown()
 
 


### PR DESCRIPTION
Runs ROS 2 integration tests as part of CI pipeline.

Updates README.md with command line example to download LoFTR weights.