### PR TITLE
Update documentation to use dockerized MapServer instead of MapProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,42 +13,39 @@ GIS system.
 
 # Mock GPS Example
 
-The below steps demonstrate how GISNav's example `MockGPSNode` ROS 2 node enables GNSS-free flight with PX4 Autopilot's 
+The below steps demonstrate how GISNav's `MockGPSNode` ROS 2 node enables GNSS-free flight with PX4 Autopilot's 
 [Mission mode][1] in a SITL simulation.
 
-You will need to have Python 3 and [NVIDIA Container Toolkit installed][2], and a [WMS endpoint][3] for high-resolution 
-aerial or satellite imagery with coverage over the flight area (San Carlos KSQL airport in CA, USA) available.
+You will need to have [NVIDIA Container Toolkit][2] for Docker installed.
 
 [1]: https://docs.px4.io/v1.12/en/flight_modes/mission.html
 
 [2]: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
 
-[3]: https://hmakelin.github.io/gisnav/pages/setup.html#wms-endpoint
-
-## Build and run GISNav in dockerized environment
-
-Replace the `<your-map-server-url>` substring below with your WMS endpoint URL and build the Docker images:
+## Build and run SITL simulation
 
 ```bash
 git clone https://github.com/hmakelin/gisnav-docker.git
 cd gisnav-docker
-docker-compose build --build-arg MAPPROXY_TILE_URL="https://<your-map-server-url>/tiles/%(z)s/%(y)s/%(x)s"
+docker-compose build --build-arg WITH_GISNAV px4-sitl
 ```
 
 > **Note** The build for the `px4-sitl` image takes a long time, especially if you are building it for the first time.
 
-Once the images have been built, run a `mapproxy` container in the background and a `px4-sitl` container in the 
+Once the `px4-sitl` image has been built, run a `mapserver` service in the background and a `px4-sitl` service in the 
 foreground (you will need to type in some commands into the PX4 shell later):
 
 ```bash
-docker-compose up -d mapproxy
+docker-compose up -d mapserver
 docker-compose up px4-sitl
 ```
 
-> **Note**
-> The `px4-sitl` container should pop up [Gazebo][4] and [QGroundControl][5] automatically once you run it. The Gazebo 
-> window may take several minutes to appear, while QGroundControl should pop up in a few seconds after running the 
-> container.
+> **Note**: 
+> * The `mapserver` container needs to download roughly 1 GB of high-resolution aerial imagery, so it may take some 
+>   time until it starts serving the WMS endpoint.
+> * The `px4-sitl` container should pop up [Gazebo][4] and [QGroundControl][5] automatically once ran. The Gazebo 
+>   window may take several minutes to appear, while QGroundControl should appear in a few seconds after running the 
+>   container.
 
 [4]: https://gazebosim.org/home
 
@@ -57,15 +54,15 @@ docker-compose up px4-sitl
 ## Upload flight plan via QGroundControl
 
 Once both the Gazebo and QGroundControl windows have appeared (QGroundControl should show the drone location near San 
-Carlos airport), use QGroundControl to upload the sample `test/assets/ksql_airport.plan` flight plan that is already 
-included inside the Docker container, and start the mission.
+Carlos airport), use QGroundControl to upload the sample `~/ksql_airport.plan` flight plan that is included inside the 
+Docker container, and then start the mission.
 
 ## Simulate GPS failure
 
 > **Warning** Do not attempt this on a real flight - simulation use only.
 
 Wait until the drone has risen to its final mission altitude. You should see a visualization of the GISNav-estimated 
-field of view projected on the ground pop up. You can then try disabling the primary GPS from your PX4 shell:
+field of view projected on the ground appear. You can then try disabling GPS from your PX4 shell:
 
 ```
 failure gps off
@@ -83,10 +80,10 @@ If the printed GPS message has a `device_id` other than 0, your PX4 is receiving
 
 # Documentation
 
-See the [latest developer documentation][8] for information on how to setup a local environment for GISNav development, 
+See the [latest developer documentation][6] for information on how to setup a local environment for GISNav development, 
 for code examples and API documentation, and for contribution guidelines.
 
-[8]: https://hmakelin.github.io/gisnav
+[6]: https://hmakelin.github.io/gisnav
 
 # License
 

--- a/config/typhoon_h480__ksql_airport.yaml
+++ b/config/typhoon_h480__ksql_airport.yaml
@@ -1,9 +1,9 @@
 mock_gps_node:
   ros__parameters:
     wms:
-      url: 'http://localhost:8080/wms'
-      version: '1.1.1'
-      layers: ['Imagery']
+      url: 'http://localhost:80/?map=/etc/mapserver/wms.map'
+      version: '1.3.0'
+      layers: ['naip-natural-color-raster']
       styles: ['']
       srs: 'EPSG:4326'
       image_format: 'image/jpeg'


### PR DESCRIPTION
* Updates Sphinx documentation and README.md to use MapServer with preloaded maps
* Also edits the config/typhoon_h480__ksql_airport.yaml file for mapserver (ideally should not need to change this whether mapproxy or mapserver is used)