### PR TITLE
Fix wrong heading in outgoing SensorGps message

### DIFF
--- a/gisnav/data.py
+++ b/gisnav/data.py
@@ -437,6 +437,7 @@ class FixedCamera:
         rT = self.pose.r.T
         assert not np.isnan(rT).any()
         gimbal_estimated_attitude = Rotation.from_matrix(rT)  # rotated map pixel frame
+
         gimbal_estimated_attitude *= Rotation.from_rotvec(-(np.pi/2) * np.array([1, 0, 0]))  # camera body
         gimbal_estimated_attitude *= Rotation.from_rotvec(
             self.image_pair.ref.rotation * np.array([0, 0, 1]))  # unrotated map pixel frame

--- a/gisnav/nodes/base_node.py
+++ b/gisnav/nodes/base_node.py
@@ -782,6 +782,8 @@ class BaseNode(Node, ABC):
             if projected_center is None:
                 self.get_logger().warn('Could not project field of view center. Using vehicle position for map center '
                                        'instead.')
+        else:
+            projected_center = None
 
         assert self._vehicle_position.z_ground is not None
         map_radius = self._get_dynamic_map_radius(self._vehicle_position.z_ground)

--- a/gisnav/nodes/base_node.py
+++ b/gisnav/nodes/base_node.py
@@ -557,7 +557,7 @@ class BaseNode(Node, ABC):
 
         gimbal_set_attitude_ned = vehicle_yaw * gimbal_set_attitude_frd
 
-        return Attitude(gimbal_set_attitude_ned.as_quat())
+        return Attitude(gimbal_set_attitude_ned.as_quat(), extrinsic=True)
 
     @property
     def _altitude_agl(self) -> Optional[float]:
@@ -650,7 +650,7 @@ class BaseNode(Node, ABC):
                 xy=GeoPoint(self._vehicle_global_position.lon, self._vehicle_global_position.lat, crs),  # lon-lat order
                 z_ground=self._altitude_agl,  # not None
                 z_amsl=self._vehicle_global_position.alt,
-                attitude=Attitude(np.append(self._vehicle_attitude.q[1:4], self._vehicle_attitude.q[0])),
+                attitude=Attitude(np.append(self._vehicle_attitude.q[1:4], self._vehicle_attitude.q[0]), extrinsic=True),
                 timestamp=self._synchronized_time
             )
             return position
@@ -1133,7 +1133,8 @@ class BaseNode(Node, ABC):
         if image_data is None or map_data is None:
             self.get_logger().warn('Missing required inputs for generating mock image PAIR.')
             return None
-        contextual_map_data = ContextualMapData(rotation=0, crop=image_data.image.dim, map_data=map_data)
+        contextual_map_data = ContextualMapData(rotation=0, crop=image_data.image.dim, map_data=map_data,
+                                                mock_data=True)
         image_pair = ImagePair(image_data, contextual_map_data)
         return image_pair
 

--- a/gisnav/nodes/mock_gps_node.py
+++ b/gisnav/nodes/mock_gps_node.py
@@ -64,7 +64,7 @@ class MockGPSNode(BaseNode):
         msg.time_utc_usec = int(time.time() * 1e6)
         msg.satellites_used = np.iinfo(np.uint8).max
         msg.time_utc_usec = int(time.time() * 1e6)
-        msg.heading = position.attitude.yaw + fixed_camera.image_pair.ref.rotation # np.nan
+        msg.heading = position.attitude.yaw
         msg.heading_offset = np.nan
         #msg.heading_accuracy = np.nan
         #msg.rtcm_injection_rate = np.nan

--- a/gisnav/nodes/mock_gps_node.py
+++ b/gisnav/nodes/mock_gps_node.py
@@ -38,7 +38,9 @@ class MockGPSNode(BaseNode):
         msg = SensorGps()
         msg.timestamp = self._synchronized_time  #position.timestamp
         #msg.timestamp_sample = msg.timestamp
-        msg.device_id = self._generate_device_id()
+        msg.timestamp_sample = 0
+        #msg.device_id = self._generate_device_id()
+        msg.device_id = 0
         msg.fix_type = 3
         msg.s_variance_m_s = np.nan
         msg.c_variance_rad = np.nan

--- a/test/assets/gscam_params.yaml
+++ b/test/assets/gscam_params.yaml
@@ -1,7 +1,7 @@
 gscam_publisher:
   ros__parameters:
     gscam_config: >
-      gst-launch-1.0 udpsrc uri=udp://127.0.0.1:5600 !
+      gst-launch-1.0 udpsrc uri=udp://127.0.0.1:5601 !
       application/x-rtp,media=video,clock-rate=90000,encoding-name=H264 !
       rtph264depay ! h264parse ! avdec_h264 ! videoconvert
     preroll: False


### PR DESCRIPTION
- Fixes wrong heading in MockGPSNode outgoing sensor_gps messages.
- Fixes a null reference when gimbal_projection is disabled.
- Changes GStreamer UDP port to 5601 (already changed in gisnav-docker version). Plan to eventually remove these duplicate `test/assets` configuration files in this repo and use the ones in `gisnav-docker` repo.