### PR TITLE
Fix Torch+CUDA issue

### DIFF
--- a/config/typhoon_h480__ksql_airport.yaml
+++ b/config/typhoon_h480__ksql_airport.yaml
@@ -22,5 +22,5 @@ mock_gps_node:
       #params_file: 'config/superglue_params.yaml'  # For parsing args for matcher's static initializer method
       params_file: 'config/loftr_params.yaml'
     debug:
-      export_position: 'position.json'
-      export_projection: 'projection.json'
+      export_position: ''
+      export_projection: ''

--- a/gisnav/data.py
+++ b/gisnav/data.py
@@ -172,7 +172,7 @@ class ContextualMapData(_ImageHolder):
     crop: Dim                       # Same value will also be found at image.dim (but not at initialization)
     map_data: MapData               # This is the original (square) map with padding
     pix_to_wgs84: np.ndarray = field(init=False)
-    mock_data: bool = False
+    mock_data: bool = False         # Indicates that this was used for field of view guess (mock map data)
 
     def _pix_to_wgs84(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Returns tuple of affine 2D transformation matrix for converting matched pixel coordinates to WGS84 coordinates

--- a/gisnav/nodes/base_node.py
+++ b/gisnav/nodes/base_node.py
@@ -9,6 +9,7 @@ import time
 import importlib
 import os
 import yaml
+import torch
 
 from abc import ABC, abstractmethod
 from multiprocessing.pool import Pool

--- a/gisnav/nodes/base_node.py
+++ b/gisnav/nodes/base_node.py
@@ -721,7 +721,11 @@ class BaseNode(Node, ABC):
         :return: Tuple containing the class type and the initialized pose estimation pool
         """
         # Use 'spawn', see: https://pytorch.org/docs/stable/notes/multiprocessing.html#cuda-in-multiprocessing
-        torch.multiprocessing.set_start_method('spawn')
+        try:
+            torch.multiprocessing.set_start_method('spawn')
+        except RuntimeError as _:
+            # context has already been set
+            pass
         pose_estimator_params = self._load_config(params_file)
         module_name, class_name = pose_estimator_params.get('class_name', '').rsplit('.', 1)
         pose_estimator = self._import_class(class_name, module_name)

--- a/gisnav/nodes/base_node.py
+++ b/gisnav/nodes/base_node.py
@@ -719,6 +719,8 @@ class BaseNode(Node, ABC):
         :param params_file: Parameter file with pose estimator full class path and initialization arguments
         :return: Tuple containing the class type and the initialized pose estimation pool
         """
+        # Use 'spawn', see: https://pytorch.org/docs/stable/notes/multiprocessing.html#cuda-in-multiprocessing
+        torch.multiprocessing.set_start_method('spawn')
         pose_estimator_params = self._load_config(params_file)
         module_name, class_name = pose_estimator_params.get('class_name', '').rsplit('.', 1)
         pose_estimator = self._import_class(class_name, module_name)


### PR DESCRIPTION
- Makes torch use 'spawn' start method as mentioned here: https://pytorch.org/docs/stable/notes/multiprocessing.html#cuda-in-multiprocessing
- Disables GeoJSON export by default in the `config/typhoon_h480__ksql_airport.yaml` file. These are probably not needed in most cases, they are not used by the mock GPS demo
- Adds a comment to clarify use of `ContextualMapData.mock_data` attribute which was added in #10 as a fix to the heading/attitude intrinsic vs. extrinsic rotations problem