### PR TITLE
Add preliminary SITL test using mavsdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ docs/_build/
 
 # Optional weights folder (LoFTR)
 weights/
+
+# SITL test log output
+test/output/
+test/sitl/output/

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,4 @@ docs/_build/
 weights/
 
 # SITL test log output
-test/output/
 test/sitl/output/

--- a/docs/pages/developer_guide.rst
+++ b/docs/pages/developer_guide.rst
@@ -301,6 +301,8 @@ See the provided ``loftr_params.yaml`` and ``superglue_params.yaml`` for example
 
 Testing
 ====================================================
+Unit & ROS 2 integration tests
+____________________________________________________
 First you must install the dev dependencies for your workspace:
 
 .. code-block:: bash
@@ -324,6 +326,14 @@ to measure:
     python3 -m coverage run --branch --include */site-packages/gisnav/* src/gisnav/test/test_mock_gps_node.py
     python3 -m coverage report
 
+SITL tests
+____________________________________________________
+SITL tests are under the ``test/sitl`` folder. They are simple Python scripts:
+
+.. code-block:: bash
+
+    cd ~/px4_ros_com_ros2/src/gisnav
+    python test/sitl_test_mock_gps_node.py
 
 Documentation
 ====================================================

--- a/docs/pages/developer_guide.rst
+++ b/docs/pages/developer_guide.rst
@@ -332,8 +332,8 @@ SITL tests are under the ``test/sitl`` folder. They are simple Python scripts:
 
 .. code-block:: bash
 
-    cd ~/px4_ros_com_ros2/src/gisnav
-    python test/sitl_test_mock_gps_node.py
+    cd ~/px4_ros_com_ros2/src/gisnav/test/sitl
+    python sitl_test_mock_gps_node.py
 
 Documentation
 ====================================================

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,14 @@
+# Sphinx
 Sphinx==4.3.2
 pydata-sphinx-theme
 autodocsumm==0.2.7
 docutils>=0.17
 myst_parser==0.16.1
 pygments==2.11.2  # make Sphinx highlighting work
+
+# Unit & ROS 2 integration tests
 pytest
 coverage
+
+# SITL tests
+mavsdk

--- a/test/assets/ksql_airport.plan
+++ b/test/assets/ksql_airport.plan
@@ -36,7 +36,7 @@
                 "doJumpId": 2,
                 "frame": 2,
                 "params": [
-                    -90,
+                    -85,
                     0,
                     0,
                     0,
@@ -47,7 +47,7 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 130,
                 "Altitude": 130,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -59,14 +59,14 @@
                     0,
                     0,
                     null,
-                    37.523640799999995,
-                    -122.2551034,
+                    37.5236489,
+                    -122.2551101,
                     130
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 130,
                 "Altitude": 130,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -78,14 +78,14 @@
                     0,
                     0,
                     null,
-                    37.5243677,
-                    -122.256137,
+                    37.52371697,
+                    -122.25300218,
                     130
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 130,
                 "Altitude": 130,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -97,14 +97,14 @@
                     0,
                     0,
                     null,
-                    37.5253963,
-                    -122.2548594,
+                    37.52176837,
+                    -122.2531202,
                     130
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 130,
                 "Altitude": 130,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -116,14 +116,14 @@
                     0,
                     0,
                     null,
-                    37.5225601,
-                    -122.25639389999999,
+                    37.52190452,
+                    -122.25684311,
                     130
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 130,
                 "Altitude": 130,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -135,8 +135,27 @@
                     0,
                     0,
                     null,
-                    37.5226161,
-                    -122.2543137,
+                    37.52347872,
+                    -122.25807692,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": 130,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 8,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.52461893,
+                    -122.25681092,
                     130
                 ],
                 "type": "SimpleItem"
@@ -144,7 +163,7 @@
             {
                 "autoContinue": true,
                 "command": 20,
-                "doJumpId": 8,
+                "doJumpId": 9,
                 "frame": 2,
                 "params": [
                     0,
@@ -159,9 +178,9 @@
             }
         ],
         "plannedHomePosition": [
-            37.52364104097109,
-            -122.25510340000132,
-            2.7443970797736887
+            37.5236489,
+            -122.2551101,
+            2.673999185660817
         ],
         "vehicleType": 2,
         "version": 2

--- a/test/sitl/sitl_test_mock_gps_node.py
+++ b/test/sitl/sitl_test_mock_gps_node.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Script for testing :class:`.MockGPSNode` in SITL simulation"""
+import sys
+import os
+import asyncio
+
+from functools import partial
+
+from mavsdk import System
+from mavsdk.log_files import LogFilesResult, LogFilesError
+
+DOCKER_CONTAINERS = ['gisnav-docker_mapserver_1', 'gisnav-docker_px4-sitl_1']
+SYS_ADDR = 'udp://0.0.0.0:14550'
+MISSION_FILE = os.path.join(os.path.dirname(__file__), '../assets/ksql_airport.plan')
+MAVLINK_CONNECTION_TIMEOUT_SEC = 15
+PRE_FLIGHT_HEALTH_CHECK_TIMEOUT_SEC = 15
+LOG_OUTPUT_PATH = os.path.join(os.path.dirname(__file__), 'output')
+
+
+async def run():
+    """Runs the SITL test"""
+    drone = System()
+
+    try:
+        connect_mavlink_ = partial(connect_mavlink, drone)
+        await asyncio.wait_for(connect_mavlink_(), timeout=MAVLINK_CONNECTION_TIMEOUT_SEC)
+    except asyncio.TimeoutError as _:
+        raise asyncio.TimeoutError(f'MAVLink connection attempt timed out at {MAVLINK_CONNECTION_TIMEOUT_SEC} seconds.')
+
+    # TODO: poll mapserver until a valid response is received
+
+    print(f'Importing mission from file {MISSION_FILE}')
+    mission_import_data = await drone.mission_raw.import_qgroundcontrol_mission(MISSION_FILE)
+
+    print(f'Uploading mission...')
+    await drone.mission_raw.upload_mission(mission_import_data.mission_items)
+
+    try:
+        check_health_ = partial(check_health, drone)
+        await asyncio.wait_for(check_health_(), timeout=PRE_FLIGHT_HEALTH_CHECK_TIMEOUT_SEC)
+    except asyncio.TimeoutError as _:
+        raise asyncio.TimeoutError(f'Pre-flight health checks failed.')
+
+    # TODO: figure out why this is needed
+    await asyncio.sleep(5)
+
+    print(f'Arming...')
+    await drone.action.arm()
+
+    print(f'Starting mission...')
+    await drone.mission_raw.start_mission()
+
+    async for mission_progress in drone.mission_raw.mission_progress():
+        if 0 < mission_progress.current < mission_progress.total:
+            print(f'Mission progress: {mission_progress.current}/{mission_progress.total}')
+        else:
+            print(f'Mission finished.')
+            break
+
+    print('Getting log entries...')
+    entries = await drone.log_files.get_entries()
+    entry = entries[0]
+
+    if not os.path.exists(LOG_OUTPUT_PATH):
+        print(f'Creating missing {LOG_OUTPUT_PATH} directory...')
+        os.makedirs(LOG_OUTPUT_PATH)
+    filename = f'gisnav-sitl-test-log_{entry.date.replace(":", "-")}.ulog'
+    output_path = os.path.join(LOG_OUTPUT_PATH, filename)
+
+    print(f'Downloading log {entry.id} from {entry.date} to {output_path}.')
+    try:
+        await drone.log_files.download_log_file(entry, output_path)
+    except LogFilesError as e:
+        if e is LogFilesResult.Result.INVALID_ARGUMENT:
+            print(f'File {output_path} possibly already exists, could not download log. Exception was: "{e}"')
+        else:
+            raise
+
+
+async def connect_mavlink(drone):
+    """Connects to drone via MAVLink"""
+    print(f'Connecting to drone at "{SYS_ADDR}"...')
+    await drone.connect(system_address=SYS_ADDR)
+    async for state in drone.core.connection_state():
+        # This might take a while assuming the Docker containers have not had time to start yet
+        if state.is_connected:
+            print(f'Connection successful.')
+            break
+
+
+async def check_health(drone):
+    """Goes through (pre-flight) health checks"""
+    print("Going through health-checks...")
+    async for health in drone.telemetry.health():
+        if health.is_global_position_ok \
+                and health.is_local_position_ok \
+                and health.is_home_position_ok \
+                and health.is_accelerometer_calibration_ok \
+                and health.is_gyrometer_calibration_ok \
+                and health.is_magnetometer_calibration_ok \
+                and health.is_armable:
+            print(f'Health-checks OK')
+            break
+
+
+def setup():
+    """Sets up SITL testing environment
+    
+    This most likely means starting supporting services with docker
+    """
+    print('Starting SITL environment...')
+    os.system('docker start ' + ' '.join(DOCKER_CONTAINERS))
+
+
+def cleanup():
+    """Cleans up after tests
+
+    Should clean up whatever was set in :meth:`.setup` (e.g. docker containers so that they won't be left running if
+    the tests fail because of an error)
+    """
+    print('Shutting down SITL environment...')
+    for container in DOCKER_CONTAINERS:
+        os.system(f'docker kill {container}')
+
+
+if __name__ == "__main__":
+    setup()
+    loop = asyncio.get_event_loop()
+    try:
+        loop.run_until_complete(run())
+    except Exception as _:
+        # TODO: handle exceptions here
+        raise
+    finally:
+        cleanup()
+    sys.exit(0)


### PR DESCRIPTION
Does not e.g. inject gps failure yet, just flies sample light plan and downloads flight logs. Also swaps the flight plan in this repository to the same one that is in gisnav-docker (eventually plan to just have them all in one repo).