### PR TITLE
Enable use of elevation data for pose estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You will need to have [NVIDIA Container Toolkit][2] for Docker installed.
 ```bash
 git clone https://github.com/hmakelin/gisnav-docker.git
 cd gisnav-docker
-docker-compose build --build-arg WITH_GISNAV px4-sitl
+docker-compose build px4-sitl
 ```
 
 > **Note** The build for the `px4-sitl` image takes a long time, especially if you are building it for the first time.

--- a/config/typhoon_h480__ksql_airport.yaml
+++ b/config/typhoon_h480__ksql_airport.yaml
@@ -4,6 +4,7 @@ mock_gps_node:
       url: 'http://localhost:80/wms'
       version: '1.3.0'
       layers: ['imagery']
+      elevation_layers: ['osm-buildings']
       styles: ['']
       srs: 'EPSG:4326'
       image_format: 'image/jpeg'
@@ -11,7 +12,7 @@ mock_gps_node:
     misc:
       attitude_deviation_threshold: 10 # degrees
       max_pitch: 30  # 30  # Used by _should_match
-      min_match_altitude: 80
+      min_match_altitude: 50
     map_update:
       update_delay: 1  # Keep low (e.g. 1 second) if vehicle flying fast or gimbal_projection: True
       gimbal_projection: True

--- a/docs/pages/developer_guide.rst
+++ b/docs/pages/developer_guide.rst
@@ -247,7 +247,7 @@ You can use the below snippets to get started with your own :class:`.PoseEstimat
             # TODO: implement initializer
             raise NotImplementedError
 
-        def estimate_pose(query, reference, k, guess):
+        def estimate_pose(query, reference, k, guess = None, elevation_ref = None):
             """Returns pose between query and reference images"""
             # Do your pose estimation magic here
             #r = ...  # np.ndarray of shape (3, 3)
@@ -271,7 +271,7 @@ If you want to create a :class:`.KeypointPoseEstimator`, you can also start with
 
     class MyPoseEstimator(KeypointPoseEstimator):
 
-        def __init__(self, ):
+        def __init__(self):
             # TODO: implement initializer
             raise NotImplementedError
 

--- a/gisnav/pose_estimators/pose_estimator.py
+++ b/gisnav/pose_estimators/pose_estimator.py
@@ -33,13 +33,15 @@ class PoseEstimator(ABC):
 
     @staticmethod
     def worker(query: np.ndarray, reference: np.ndarray, k: np.ndarray,
-               guess: Optional[Tuple[np.ndarray, np.ndarray]]) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+               guess: Optional[Tuple[np.ndarray, np.ndarray]] = None,
+               elevation_reference: Optional[np.ndarray] = None) -> Optional[Tuple[np.ndarray, np.ndarray]]:
         """Returns pose between provided images, or None if pose cannot be estimated
 
         :param query: The first (query) image for pose estimation
         :param reference: The second (reference) image for pose estimation
         :param k: Camera intrinsics matrix of shape (3, 3)
         :param guess: Optional initial guess for camera pose
+        :param elevation_reference: Optional elevation raster (same size resolution as reference image, grayscale)
         :return: Pose tuple consisting of a rotation (3, 3) and translation (3, 1) numpy arrays
         """
         pose_estimator: PoseEstimator = globals()[PoseEstimator.POSE_ESTIMATOR_GLOBAL_VAR]
@@ -47,7 +49,7 @@ class PoseEstimator(ABC):
         if guess is not None:
             assert_pose(guess)
 
-        pose = pose_estimator.estimate_pose(query, reference, k, guess)
+        pose = pose_estimator.estimate_pose(query, reference, k, guess, elevation_reference)
 
         # Do independent check - child class might not check their output
         if pose is not None:
@@ -57,13 +59,15 @@ class PoseEstimator(ABC):
 
     @abstractmethod
     def estimate_pose(self, query: np.ndarray, reference: np.ndarray, k: np.ndarray,
-                      guess: Optional[Tuple[np.ndarray, np.ndarray]]) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+                      guess: Optional[Tuple[np.ndarray, np.ndarray]] = None,
+                      elevation_reference: Optional[np.ndarray] = None) -> Optional[Tuple[np.ndarray, np.ndarray]]:
         """Returns pose between provided images, or None if pose cannot be estimated
 
         :param query: The first (query) image for pose estimation
         :param reference: The second (reference) image for pose estimation
         :param k: Camera intrinsics matrix of shape (3, 3)
         :param guess: Optional initial guess for camera pose
+        :param elevation_reference: Optional elevation raster (same size resolution as reference image, grayscale)
         :return: Pose tuple of rotation (3, 3) and translation (3, 1) numpy arrays, or None if could not estimate
         """
         pass


### PR DESCRIPTION
Adds support for passing elevation rasters to pose estimator. For example, the WMS server could serve rasterized OSM Buildings as in the updated `px4-sitl` Docker image: https://github.com/hmakelin/gisnav-docker/pull/11, or a DEM raster (height relative to ground below drone). Using elevation rasters with height larger than 255 units (current implementation uses uint8 array for storing the elevation) has not been tested but there is a TODO left for it in the code.

Note: The Gazebo world buildings are featureless blocks so in the simulation (almost) all matched keypoints will be on the ground (z=0) plane.

Other:

- Removes `--build-arg WITH_GISNAV` from README.md example, not needed after updates introduced in https://github.com/hmakelin/gisnav-docker/pull/8