### PR TITLE
Exclude Jupyter notebooks from GitHub Linguist stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ignore Jupyter notebooks because embedded images and other metadata inflate number of lines of code, making GitHub
+# misreport repository language as "Jupyter Notebook"
+*.ipynb linguist-documentation


### PR DESCRIPTION
Repo language is listed as "Jupyter Notebook" (possibly because of embedded images in .ipynb file being counted as lines of code). This should make Linguist ignore the notebook and list the repo as a Python project again.