### PR TITLE
Use ROS remapping for camera info and image topics

### DIFF
--- a/config/test_typhoon_h480__ksql_airport.yaml
+++ b/config/test_typhoon_h480__ksql_airport.yaml
@@ -12,8 +12,6 @@ mock_gps_node:
       request_timeout: 10
     misc:
       autopilot: 'gisnav.autopilots.px4_micrortps.PX4microRTPS'
-      image_topic: '/camera/image_raw'
-      camera_info_topic: '/camera/camera_info'
       mock_gps_selection: 1
       attitude_deviation_threshold: 10
       #max_pitch: 30

--- a/config/typhoon_h480__ksql_airport.yaml
+++ b/config/typhoon_h480__ksql_airport.yaml
@@ -11,8 +11,6 @@ mock_gps_node:
       request_timeout: 10
     misc:
       autopilot: 'gisnav.autopilots.px4_micrortps.PX4microRTPS'
-      image_topic: '/camera/image_raw'
-      camera_info_topic: '/camera/camera_info'
       attitude_deviation_threshold: 10 # degrees
       max_pitch: 30  # 30  # Used by _should_match
       min_match_altitude: 50

--- a/config/typhoon_h480__ksql_airport_ardupilot.yaml
+++ b/config/typhoon_h480__ksql_airport_ardupilot.yaml
@@ -11,8 +11,6 @@ mock_gps_node:
       request_timeout: 10
     misc:
       autopilot: 'gisnav.autopilots.ardupilot_mavros.ArduPilotMAVROS'
-      image_topic: '/camera/image_raw'
-      camera_info_topic: '/camera/camera_info'
       attitude_deviation_threshold: 10 # degrees
       max_pitch: 50  # 30  # Make bigger with static_camera: True  # Used by _should_match
       min_match_altitude: 50

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,16 @@ html_theme_options = {
         "image_light": "img/logo.png",
         "image_dark": "img/logo_inverted.png",
     },
-    "collapse_navigation": True
+    "collapse_navigation": True,
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/hmakelin/gisnav",
+            "icon": "fab fa-github",
+            "type": "fontawesome",
+        }
+    ],
+    "icon_links_label": "Quick Links",
 }
 
 # Make version number accessible in .rst files

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ sys.path.append(os.path.abspath(superglue_dir))
 # -- Project information -----------------------------------------------------
 
 project = package_data.package_name
-copyright = f'2021, {package_data.author}'
+copyright = f'2022, {package_data.author}'
 author = package_data.author
 
 # -- General configuration ---------------------------------------------------

--- a/docs/pages/api_documentation.rst
+++ b/docs/pages/api_documentation.rst
@@ -8,6 +8,10 @@ will only be interested in the :class:`.BaseNode` and :class:`.PoseEstimator` cl
 
 .. _GISNav ROS 2 package: https://gitlab.com/px4-ros2-map-nav/python_px4_ros2_map_nav
 
+.. note::
+    GISNav is under active development and stability of the API is not guaranteed. Use a specific commit or version tag
+    to mitigate the impact of breaking changes.
+
 Indices and Tables
 =================================================
 Use the search in the sidebar or these indices to find what you are looking for.

--- a/docs/pages/developer_guide.rst
+++ b/docs/pages/developer_guide.rst
@@ -6,6 +6,10 @@ Developer Guide
     GISNav is untested and has only been demonstrated in a software-in-the-loop (SITL) simulation environment.
     Do not use this software for real drone flights.
 
+.. note::
+    GISNav is under active development and stability of the API is not guaranteed. Use a specific commit or version tag
+    to mitigate the impact of breaking changes.
+
 This section provides instruction on how you can integrate GISNav with your project as well as configure and extend
 it to match your use case.
 

--- a/docs/pages/developer_guide.rst
+++ b/docs/pages/developer_guide.rst
@@ -318,6 +318,17 @@ the PX4 User Guide.
 .. seealso::
     `PX4-ROS 2 bridge <https://docs.px4.io/master/en/ros/ros2_comm.html>`_ for more information on the PX4-ROS 2 bridge
 
+Remap ROS 2 Topics
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+By default, the :class:`.CameraInfo` and :class:`px4_msgs.Image` messages are expected at ``camera/camera_info`` and
+``camera/image_raw`` topics, respectively. The topics can be remapped:
+
+.. code-block:: bash
+
+    ros2 run gisnav mock_gps_node --mavros --ros-args --log-level info \
+        --params-file src/gisnav/config/typhoon_h480__ksql_airport_ardupilot.yaml \
+         -r camera/camera_info:=camera_info -r camera/image_raw:=image_raw
+
 Testing
 ====================================================
 Unit & ROS 2 integration tests

--- a/docs/pages/get_started.rst
+++ b/docs/pages/get_started.rst
@@ -1,7 +1,9 @@
 **************************************************
 Get Started
 **************************************************
+..
+    Skip GitHub video link (:start-after: .mp4)
+
 .. include:: ../../README.md
     :parser: myst_parser.sphinx_
-
-
+    :start-after: .mp4

--- a/gisnav/autopilots/ardupilot_mavros.py
+++ b/gisnav/autopilots/ardupilot_mavros.py
@@ -41,16 +41,13 @@ class ArduPilotMAVROS(Autopilot):
     }
     """ROS topics to subscribe"""
 
-    def __init__(self, node: rclpy.node.Node, camera_info_topic: str, image_topic: str,
-                 image_callback: Callable[[Image], None]) -> None:
+    def __init__(self, node: rclpy.node.Node, image_callback: Callable[[Image], None]) -> None:
         """Initialize class
 
         :param node: Parent node that handles the ROS subscriptions
-        :param camera_info_topic: ROS camera info topic to subscribe to
-        :param image_topic: ROS camera image (raw) topic to subscribe to
         :param image_callback: Callback function for camera image
         """
-        super().__init__(node, camera_info_topic, image_topic, image_callback)
+        super().__init__(node, image_callback)
 
         # TODO: copy to shared folder and use relative path
         self._egm96 = GeoidPGM('/usr/share/GeographicLib/geoids/egm96-5.pgm', kind=-3)

--- a/gisnav/autopilots/px4_micrortps.py
+++ b/gisnav/autopilots/px4_micrortps.py
@@ -40,16 +40,13 @@ class PX4microRTPS(Autopilot):
     }
     """ROS topics to subscribe"""
 
-    def __init__(self, node: rclpy.node.Node, camera_info_topic: str, image_topic: str,
-                 image_callback: Callable[[Image], None]) -> None:
+    def __init__(self, node: rclpy.node.Node, image_callback: Callable[[Image], None]) -> None:
         """Initialize class
 
         :param node: Parent node that handles the ROS subscriptions
-        :param camera_info_topic: ROS camera info topic to subscribe to
-        :param image_topic: ROS camera image (raw) topic to subscribe to
         :param image_callback: Callback function for camera image
         """
-        super().__init__(node, camera_info_topic, image_topic, image_callback)
+        super().__init__(node, image_callback)
 
         self._setup_subscribers()
 

--- a/gisnav/nodes/base_node.py
+++ b/gisnav/nodes/base_node.py
@@ -81,12 +81,6 @@ class BaseNode(Node, ABC):
     ROS_D_MISC_AUTOPILOT = 'gisnav.autopilots.px4_micrortps.PX4microRTPS'
     """Default autopilot adapter"""
 
-    ROS_D_MISC_IMAGE_TOPIC = '/camera/image_raw'
-    """Default ROS image topic name"""
-
-    ROS_D_MISC_CAMERA_INFO_TOPIC = '/camera/camera_info'
-    """Default ROS camera info topic name"""
-
     ROS_D_STATIC_CAMERA = False
     """Default value for static camera flag (true for static camera facing down from vehicle body)"""
 
@@ -183,8 +177,6 @@ class BaseNode(Node, ABC):
         ('wms.srs', ROS_D_WMS_SRS),
         ('wms.request_timeout', ROS_D_WMS_REQUEST_TIMEOUT),
         ('misc.autopilot', ROS_D_MISC_AUTOPILOT, read_only),
-        ('misc.camera_info_topic', ROS_D_MISC_CAMERA_INFO_TOPIC, read_only),
-        ('misc.image_topic', ROS_D_MISC_IMAGE_TOPIC, read_only),
         ('misc.static_camera', ROS_D_STATIC_CAMERA, read_only),
         ('misc.attitude_deviation_threshold', ROS_D_MISC_ATTITUDE_DEVIATION_THRESHOLD),
         ('misc.max_pitch', ROS_D_MISC_MAX_PITCH),
@@ -234,12 +226,8 @@ class BaseNode(Node, ABC):
         # Autopilot bridge
         ap = self.get_parameter('misc.autopilot').get_parameter_value().string_value or self.ROS_D_MISC_AUTOPILOT
         ap: Autopilot = self._load_autopilot(ap)
-        image_topic = self.get_parameter('misc.image_topic').get_parameter_value().string_value \
-                      or self.ROS_D_MISC_IMAGE_TOPIC
-        camera_info_topic = self.get_parameter('misc.camera_info_topic').get_parameter_value().string_value \
-                      or self.ROS_D_MISC_CAMERA_INFO_TOPIC
         # TODO: implement passing init args, kwargs
-        self._bridge = ap(self, camera_info_topic, image_topic, self._image_raw_callback)
+        self._bridge = ap(self, self._image_raw_callback)
 
         # Converts image_raw to cv2 compatible image
         self._cv_bridge = CvBridge()


### PR DESCRIPTION
Makes CameraInfo and Image topic names static (no longer ROS parameters). Configuration of the topic names should be done through ROS topic name remapping instead. Includes a remapping example in the Sphinx docs.

Other minor changes to Sphinx docs:
- Fixes copyright year
- Adds a notice of active development (=unstable API)
- Fixes (=does not include) broken mock GPS demo video link in Sphinx docs Get Started page
- Adds GitHub repo icon link to Sphinx docs navbar