### PR TITLE
Update defaults for PX4 v1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,19 @@ You will need to have [NVIDIA Container Toolkit][2] for Docker installed.
 ```bash
 git clone https://github.com/hmakelin/gisnav-docker.git
 cd gisnav-docker
-docker-compose build sitl
+docker-compose -f docker-compose.yaml -f docker-compose.demo.yaml build sitl
 ```
 
 Once the `sitl` image has been built, run the `mapserver` and `sitl` services:
 
 ```bash
-docker-compose up -d mapserver sitl
+docker-compose -f docker-compose.yaml -f docker-compose.demo.yaml up -d mapserver sitl
 ```
 
 > **Note**:
 > * The build for the `sitl` image takes a long time.
 > * The `mapserver` container needs to download roughly 1 GB of high-resolution aerial imagery, so it may take some 
 >   time until it starts serving the WMS endpoint.
-> * Prebuilt [sitl][4] and [mapserver][5] images for the demo are available in Docker Hub in case you have problems with
->   the build process.
 
 [4]: https://hub.docker.com/r/hmakelin/gisnav-sitl
 [5]: https://hub.docker.com/r/hmakelin/gisnav-mapserver

--- a/README.md
+++ b/README.md
@@ -7,42 +7,47 @@ https://user-images.githubusercontent.com/22712178/187902004-480397cc-460f-4d57-
 
 GISNav is a ROS 2 package that enables map-based visual navigation for airborne drones **in a simulation environment**.
 
-GISNav provides an *accurate* **global** position for an airborne drone by visually comparing frames from the drone's 
-nadir-facing camera to a map of the drone's *approximate* global position retrieved from an underlying 
-GIS system.
+GISNav provides a *precise* global position for an airborne drone by visually comparing frames from the drone's 
+nadir-facing camera to a map of the drone's *approximate* global position retrieved from an underlying GIS system.
 
 # Mock GPS Example
 
-The below steps demonstrate how GISNav's `MockGPSNode` ROS 2 node enables GNSS-free flight with PX4 Autopilot's 
-[Mission mode][1] in a SITL simulation.
+The below steps demonstrate how GISNav enables GNSS-free flight with PX4 Autopilot's [Mission mode][1] in a SITL 
+simulation.
 
-You will need to have [NVIDIA Container Toolkit][2] for Docker installed.
+You will need to have the [docker compose plugin][2] and [NVIDIA Container Toolkit][3] installed.
 
 [1]: https://docs.px4.io/v1.12/en/flight_modes/mission.html
-
-[2]: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+[2]: https://docs.docker.com/compose/install/linux/
+[3]: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
 
 ## Build and run SITL simulation
 
+Build the Docker images:
 ```bash
-git clone https://github.com/hmakelin/gisnav-docker.git
-cd gisnav-docker
-docker-compose -f docker-compose.yaml -f docker-compose.demo.yaml build sitl
+git clone https://github.com/hmakelin/gisnav.git
+cd gisnav
+docker compose build px4 qgc mapserver micro-ros-agent gisnav
 ```
 
-Once the `sitl` image has been built, run the `mapserver` and `sitl` services:
-
+Run GISNav along with supporting services:
 ```bash
-docker-compose -f docker-compose.yaml -f docker-compose.demo.yaml up -d mapserver sitl
+docker compose up px4 qgc mapserver micro-ros-agent gisnav 
 ```
 
-> **Note**:
-> * The build for the `sitl` image takes a long time.
-> * The `mapserver` container needs to download roughly 1 GB of high-resolution aerial imagery, so it may take some 
->   time until it starts serving the WMS endpoint.
+> **Note**
+> * The build for the `px4` and `gisnav` images may take a long time.
+> * The `mapserver` container needs to download roughly 1 GB of high-resolution aerial imagery when ran for the first 
+>   time, so it may take some time until it starts serving the WMS endpoint.
+> * If the Gazebo and QGroundControl windows do not appear on your screen you may need to expose your ``xhost`` to your 
+>   Docker containers (see e.g. [ROS GUI Tutorial][4]):
+>   ```bash
+>   for containerId in $(docker ps -f name=gisnav -q); do
+>     xhost +local:$(docker inspect --format='{{ .Config.Hostname }}' $containerId)
+>   done
+>   ```
 
-[4]: https://hub.docker.com/r/hmakelin/gisnav-sitl
-[5]: https://hub.docker.com/r/hmakelin/gisnav-mapserver
+[4]: http://wiki.ros.org/docker/Tutorials/GUI
 
 ## Upload flight plan via QGroundControl
 
@@ -52,11 +57,9 @@ Docker container, and then start the mission.
 
 ## Simulate GPS failure
 
-> **Warning** Do not attempt this on a real flight - simulation use only.
-
 Wait until the drone has risen to its final mission altitude. You should see a visualization of the GISNav-estimated 
-field of view projected on the ground appear. You can then try disabling GPS from the *nsh* console running on the drone
-through your [MAVLink Shell][6] *(accessible e.g. through QGroundControl > Analyze Tools > MAVLink Console)*:
+field of view projected on the ground appear. You can then try disabling GPS through your [MAVLink Shell][5] 
+*(accessible e.g. through QGroundControl > Analyze Tools > MAVLink Console)*:
 
 ```
 failure gps off
@@ -73,14 +76,14 @@ listener sensor_gps
 If the printed GPS message has a `satellites_used` field value of `255`, your PX4 is receiving the mock GPS node output 
 as expected.
 
-[6]: https://docs.px4.io/main/en/debug/mavlink_shell.html#qgroundcontrol
+[5]: https://docs.px4.io/main/en/debug/mavlink_shell.html#qgroundcontrol
 
 # Documentation
 
-See the [latest developer documentation][7] for information on how to setup a local environment for GISNav development, 
+See the [latest developer documentation][6] for information on how to setup a local environment for GISNav development, 
 for code examples and API documentation, and for contribution guidelines.
 
-[7]: https://hmakelin.github.io/gisnav
+[6]: https://hmakelin.github.io/gisnav
 
 # License
 

--- a/docker-compose.ardupilot.yaml
+++ b/docker-compose.ardupilot.yaml
@@ -1,0 +1,5 @@
+version: "3.4"
+
+services:
+  gisnav:
+    command: bash -c "source ~/colcon_ws/install/setup.bash && ros2 launch gisnav ardupilot.launch.py"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -113,6 +113,7 @@ services:
     network_mode: host
     stdin_open: true
     tty: true
+    #privileged: True
     deploy:
       resources:
         reservations:
@@ -120,4 +121,3 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [ gpu ]
-    command: bash -c "cd ~ && make gazebo"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,8 @@ services:
       - NAIP_GDOWN_ID=16M_kbsLpF3t87KC2n9YgqGEBA5h0lG7U
       - OSM_GDOWN_ID=1snGYjWxs71m6I-qxKsmUzch_bAfQtrEW
     volumes:
-      - $PWD/mapserver/mapfiles/mapserver.map:/etc/mapserver/mapserver.map:ro
-      - $PWD/mapserver/setup_mapserver.sh:/etc/mapserver/setup_mapserver.sh:ro
+      - $PWD/docker/mapserver/mapfiles/mapserver.map:/etc/mapserver/mapserver.map:ro
+      - $PWD/docker/mapserver/setup_mapserver.sh:/etc/mapserver/setup_mapserver.sh:ro
     entrypoint: /etc/mapserver/setup_mapserver.sh
 
   mapproxy:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,123 @@
+version: "3.4"
+
+services:
+  mapserver:
+    image: camptocamp/mapserver
+    network_mode: host
+    environment:
+      - NAIP_GDOWN_ID=16M_kbsLpF3t87KC2n9YgqGEBA5h0lG7U
+      - OSM_GDOWN_ID=1snGYjWxs71m6I-qxKsmUzch_bAfQtrEW
+    volumes:
+      - $PWD/mapserver/mapfiles/mapserver.map:/etc/mapserver/mapserver.map:ro
+      - $PWD/mapserver/setup_mapserver.sh:/etc/mapserver/setup_mapserver.sh:ro
+    entrypoint: /etc/mapserver/setup_mapserver.sh
+
+  mapproxy:
+    build:
+      context: docker/mapproxy
+      dockerfile: Dockerfile
+    network_mode: host
+
+  micro-ros-agent:
+    image: microros/micro-ros-agent:foxy
+    command: udp4 -p 8888
+    network_mode: host
+    volumes:
+      - /dev/shm:/dev/shm
+
+  mavros:
+    build:
+      context: docker/mavros
+      dockerfile: Dockerfile
+    environment:
+      - FASTRTPS_DEFAULT_PROFILES_FILE=/disable_shared_memory.xml
+    network_mode: host
+    volumes:
+      - /dev/shm:/dev/shm
+
+  qgc:
+    build:
+      context: docker/qgc
+      dockerfile: Dockerfile
+    environment:
+      - QT_X11_NO_MITSHM=1
+      - DISPLAY=${DISPLAY}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:ro
+      - /dev/shm:/dev/shm
+      - /dev/dri:/dev/dri
+    network_mode: host
+    stdin_open: true
+    tty: true
+
+  gisnav:
+    build:
+      context: docker/gisnav
+      dockerfile: Dockerfile
+    environment:
+      - FASTRTPS_DEFAULT_PROFILES_FILE=/disable_shared_memory.xml
+    volumes:
+      - /dev/dri:/dev/dri
+    network_mode: host
+    stdin_open: true
+    tty: true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [ gpu ]
+    command: bash -c "source /opt/ros/foxy/setup.bash && source ~/colcon_ws/install/setup.bash && ros2 launch gisnav px4.launch.py"
+
+  px4:
+    build:
+      context: docker/px4
+      dockerfile: Dockerfile
+    environment:
+      - QT_X11_NO_MITSHM=1
+      - DISPLAY=${DISPLAY}
+      - GAZEBO_HEADLESS=${GAZEBO_HEADLESS}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:ro
+      - /dev/shm:/dev/shm
+      - /dev/dri:/dev/dri
+    network_mode: host
+    stdin_open: true
+    tty: true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [ gpu ]
+
+  #ardupilot:
+  #  build:
+  #    context: https://github.com/ArduPilot/ardupilot.git
+  #    dockerfile: https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Dockerfile
+
+  ardupilot:
+    build:
+      context: docker/ardupilot
+      dockerfile: Dockerfile
+    environment:
+      - QT_X11_NO_MITSHM=1
+      - DISPLAY=${DISPLAY}
+      - GAZEBO_HEADLESS=${GAZEBO_HEADLESS}
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:ro
+      - /dev/shm:/dev/shm
+      - /dev/dri:/dev/dri
+    network_mode: host
+    stdin_open: true
+    tty: true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [ gpu ]
+    command: bash -c "cd ~ && make gazebo"

--- a/docker/ardupilot/Dockerfile
+++ b/docker/ardupilot/Dockerfile
@@ -1,0 +1,67 @@
+FROM ros:foxy
+
+LABEL maintainer="Harri Makelin <hmakelin@protonmail.com>"
+
+ARG USERNAME=gisnav
+ARG UID=1000
+ARG GID=$UID
+
+# Set 'gisnav' as default user and add it to sudo'ers
+RUN apt-get update --fix-missing && \
+    apt-get install -y sudo wget && \
+    groupadd --gid $GID $USERNAME && useradd --uid $UID --gid $GID -m $USERNAME && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME
+USER $USERNAME
+
+# Install required tools
+RUN sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main"  \
+      > /etc/apt/sources.list.d/gazebo-stable.list' && \
+    wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add - && \
+    sudo apt-get update && \
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -y install git gitk git-gui python3-pip python-is-python3 gazebo11 \
+      gazebo11-common libgazebo11-dev libgazebo11 ros-foxy-gazebo-ros-pkgs ros-foxy-gazebo-plugins ros-foxy-gazebo-dev \
+      ros-foxy-gazebo-ros && \
+    pip install --upgrade pymavlink MAVProxy pexpect
+
+# Clone ArduPilot and update submodules
+RUN cd $HOME && \
+    git clone https://github.com/ArduPilot/ardupilot && \
+    cd ardupilot && \
+    git submodule update --init --recursive
+
+# Install ArduPilot prerequisites
+# The script requires the USER env variable be set to ${USERNAME}
+SHELL ["/bin/bash", "-c"]
+RUN cd $HOME/ardupilot/ && \
+    export USER=$USERNAME && \
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y keyboard-configuration && \
+    Tools/environment_install/install-prereqs-ubuntu.sh -y
+
+# Update PATH
+ENV PATH="/usr/lib/ccache:${PATH}:${HOME}/ardupilot/Tools/autotest"
+
+# Install Gazebo plugin
+RUN cd $HOME && \
+    git clone https://github.com/hmakelin/ardupilot_gazebo && \
+    cd ardupilot_gazebo && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make -j4 && \
+    sudo make install && \
+    echo 'source /usr/share/gazebo/setup.sh' >> ~/.bashrc && \
+    echo 'export GAZEBO_MODEL_PATH=~/ardupilot_gazebo/models' >> ~/.bashrc && \
+    echo 'export GAZEBO_RESOURCE_PATH=~/ardupilot_gazebo/worlds:${GAZEBO_RESOURCE_PATH}' >> ~/.bashrc
+
+# Make initial build
+RUN cd $HOME/ardupilot && \
+    source ~/.profile && \
+    $(sim_vehicle.py -v ArduCopter -f gazebo-iris -L KSQL_Airport | grep -m 1 "BUILD SUMMARY") || echo "Gazebo built."
+
+# Copy and apply configuration files, add SITL simulation demo location
+COPY * /
+RUN sudo mv -t $HOME/ /gazebo-iris.parm /Makefile && \
+    cat $HOME/gazebo-iris.parm >> $HOME/ardupilot/Tools/autotest/default_params/gazebo-iris.parm && \
+    echo "KSQL_Airport=37.523640,-122.255122,1.7,90" >> $HOME/ardupilot/Tools/autotest/locations.txt
+
+CMD ["bash"]

--- a/docker/ardupilot/Dockerfile
+++ b/docker/ardupilot/Dockerfile
@@ -38,7 +38,7 @@ RUN cd $HOME/ardupilot/ && \
     Tools/environment_install/install-prereqs-ubuntu.sh -y
 
 # Update PATH
-ENV PATH="/usr/lib/ccache:${PATH}:${HOME}/ardupilot/Tools/autotest"
+ENV PATH="/usr/lib/ccache:/home/$USERNAME/.local/bin:${PATH}:/home/$USERNAME/ardupilot/Tools/autotest"
 
 # Install Gazebo plugin
 RUN cd $HOME && \
@@ -64,4 +64,4 @@ RUN sudo mv -t $HOME/ /gazebo-iris.parm /Makefile && \
     cat $HOME/gazebo-iris.parm >> $HOME/ardupilot/Tools/autotest/default_params/gazebo-iris.parm && \
     echo "KSQL_Airport=37.523640,-122.255122,1.7,90" >> $HOME/ardupilot/Tools/autotest/locations.txt
 
-CMD ["bash"]
+CMD cd $HOME && make sim_vehicle

--- a/docker/ardupilot/Makefile
+++ b/docker/ardupilot/Makefile
@@ -1,0 +1,14 @@
+SHELL:=/bin/bash
+
+sim_vehicle:
+	sim_vehicle.py -v ArduCopter -f gazebo-iris -L KSQL_Airport -m '--cmd="module load GPSInput"' &
+
+gazebo: sim_vehicle
+	cd ${HOME} && \
+	if [ -z ${GAZEBO_HEADLESS} ]; then \
+		echo "Launching Gazebo client & server..."; \
+		gazebo --verbose worlds/ksql_airport.world; \
+	else \
+		echo "Launching Gazebo in headless mode..."; \
+		gzserver --verbose worlds/ksql_airport.world; \
+	fi

--- a/docker/ardupilot/Makefile
+++ b/docker/ardupilot/Makefile
@@ -1,14 +1,14 @@
 SHELL:=/bin/bash
 
-sim_vehicle:
-	sim_vehicle.py -v ArduCopter -f gazebo-iris -L KSQL_Airport -m '--cmd="module load GPSInput"' &
+sim_vehicle: gazebo
+	sim_vehicle.py -v ArduCopter -f gazebo-iris -L KSQL_Airport -m '--cmd="module load GPSInput"'
 
-gazebo: sim_vehicle
+gazebo:
 	cd ${HOME} && \
 	if [ -z ${GAZEBO_HEADLESS} ]; then \
 		echo "Launching Gazebo client & server..."; \
-		gazebo --verbose worlds/ksql_airport.world; \
+		gazebo --verbose worlds/ksql_airport.world & \
 	else \
 		echo "Launching Gazebo in headless mode..."; \
-		gzserver --verbose worlds/ksql_airport.world; \
+		gzserver --verbose worlds/ksql_airport.world & \
 	fi

--- a/docker/ardupilot/gazebo-iris.parm
+++ b/docker/ardupilot/gazebo-iris.parm
@@ -1,0 +1,13 @@
+# SIMULATION USE ONLY
+# ArduPilot mock GPS SITL simulation demo default parameters
+# Disable GPS arming check (GPS2 will not work until already flying) and use best GPS
+# Use MAVLink (14) for second GPS type
+# Use 2D position only with EK2 (no velocity estimates)
+ARMING_CHECK 0
+AHRS_EKF_TYPE 2
+EK2_ENABLE 1
+EK3_ENABLE 0
+EK2_GPS_TYPE 2
+GPS_TYPE2 14
+SIM_GPS2_TYPE 14
+GPS_AUTO_SWITCH 1

--- a/docker/gisnav/Dockerfile
+++ b/docker/gisnav/Dockerfile
@@ -1,0 +1,53 @@
+FROM ros:foxy
+
+ARG USERNAME=gisnav
+ARG UID=1000
+ARG GID=$UID
+
+RUN apt-get update --fix-missing && \
+    apt-get install sudo && \
+    groupadd --gid $GID $USERNAME && useradd --uid $UID --gid $GID -m $USERNAME && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME
+USER $USERNAME
+
+# Install GISNav & colcon dependencies
+RUN mkdir -p $HOME/colcon_ws/src && \
+    cd $HOME/colcon_ws/src && \
+    git clone --branch hmakelin-update-px4-v1.14 https://github.com/hmakelin/gisnav.git && \
+    git clone https://github.com/hmakelin/gisnav_msgs.git && \
+    git clone https://github.com/px4/px4_msgs.git && \
+    rosdep update && \
+    rosdep install --from-paths . -y --ignore-src
+
+# Install LoFTR
+RUN cd $HOME/colcon_ws/src/gisnav && \
+    git submodule update --init gisnav/pose_estimators/third_party/LoFTR && \
+    sudo apt-get -y install python3-pip && \
+    pip3 install gdown && \
+    mkdir weights && \
+    cd weights && \
+    $HOME/.local/lib/$USERNAME/gdown https://drive.google.com/uc?id=1M-VD35-qdB5Iw-AtbDBCKC7hPolFW9UY
+
+# Python dependencies
+RUN cd $HOME/colcon_ws/src/gisnav && \
+    pip3 install -r requirements.txt  && \
+    pip3 install --upgrade numpy python-dateutil
+
+# GeographicLib
+RUN sudo apt-get -y install ros-foxy-mavros ros-foxy-mavros-extras && \
+    cd $HOME && \
+    wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh && \
+    sudo bash ./install_geographiclib_datasets.sh
+
+# Build
+SHELL ["/bin/bash", "-c"]
+RUN cd $HOME/colcon_ws && \
+    source /opt/ros/foxy/setup.bash && \
+    colcon build
+
+# Clean
+RUN sudo apt-get clean && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+COPY * /
+RUN sudo chmod 755 /disable_shared_memory.xml

--- a/docker/gisnav/Dockerfile
+++ b/docker/gisnav/Dockerfile
@@ -13,7 +13,7 @@ USER $USERNAME
 # Install GISNav & colcon dependencies
 RUN mkdir -p $HOME/colcon_ws/src && \
     cd $HOME/colcon_ws/src && \
-    git clone --branch hmakelin-update-px4-v1.14 https://github.com/hmakelin/gisnav.git && \
+    git clone https://github.com/hmakelin/gisnav.git && \
     git clone https://github.com/hmakelin/gisnav_msgs.git && \
     git clone https://github.com/px4/px4_msgs.git && \
     rosdep update && \

--- a/docker/gisnav/disable_shared_memory.xml
+++ b/docker/gisnav/disable_shared_memory.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles" >
+    <transport_descriptors>
+        <transport_descriptor>
+            <transport_id>CustomUdpTransport</transport_id>
+            <type>UDPv4</type>
+        </transport_descriptor>
+    </transport_descriptors>
+    <participant profile_name="participant_profile" is_default_profile="true">
+        <rtps>
+            <userTransports>
+                <transport_id>CustomUdpTransport</transport_id>
+            </userTransports>
+            <useBuiltinTransports>false</useBuiltinTransports>
+        </rtps>
+    </participant>
+</profiles>

--- a/docker/mapproxy/Dockerfile
+++ b/docker/mapproxy/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:20.04
+
+ARG CONFIG_FILE=yaml/mapproxy.yaml
+ARG HOST=localhost
+ARG PORT=80
+ARG MAPPROXY_TILE_URL
+
+ENV CONFIG_FILE=${CONFIG_FILE}
+ENV HOST=${HOST}
+ENV PORT=${PORT}
+ENV MAPPROXY_TILE_URL=${MAPPROXY_TILE_URL}
+
+# Check that the tile endpoint url was provided as build argument
+RUN if [ -z "$MAPPROXY_TILE_URL" ]; \
+        then \
+            tput setaf 1; \
+            echo -e "\$MAPPROXY_TILE_URL is empty! Provide it with --build-arg MAPPROXY_TILE_URL=\"url\"."; \
+            tput sgr0; \
+            false; \
+        else \
+            echo "Using ${MAPPROXY_TILE_URL} for tile endpoint."; \
+    fi
+
+# Install MapProxy along with required & optional dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip python3-pil python3-yaml libproj-dev libgeos-dev \
+        python3-lxml libgdal-dev python3-shapely && \
+    pip3 install MapProxy
+
+# Copy configuration file over to $HOME
+# MapProxy config files can't use environment variables so do tile URL substitution manually
+COPY ${CONFIG_FILE} /
+RUN mv $(basename $CONFIG_FILE) $HOME/$(basename $CONFIG_FILE) && \
+    sed -i -e "s#\$MAPPROXY_TILE_URL#$MAPPROXY_TILE_URL#g" $HOME/$(basename $CONFIG_FILE)
+
+# Expose port for incoming WMS requests
+EXPOSE $PORT/tcp
+
+# Start the MapProxy server
+CMD mapproxy-util serve-develop -b ${HOST}:${PORT} ${HOME}/$(basename $CONFIG_FILE)

--- a/docker/mapproxy/yaml/mapproxy.yaml
+++ b/docker/mapproxy/yaml/mapproxy.yaml
@@ -1,0 +1,21 @@
+layers:
+  - name: imagery
+    title: High resolution satellite or aerial imagery.
+    sources: [imagery_cache]
+
+caches:
+  imagery_cache:
+    grids: [GLOBAL_WEBMERCATOR]
+    sources: [imagery_source]
+
+sources:
+  imagery_source:
+    type: tile
+    grid: GLOBAL_WEBMERCATOR
+    url: $MAPPROXY_TILE_URL
+
+services:
+  wms:
+    md:
+      title: MapProxy WMS Proxy
+      abstract: Example MapProxy configuration for proxying a tile-based endpoint as a cached WMS service.

--- a/docker/mapserver/mapfiles/mapserver.map
+++ b/docker/mapserver/mapfiles/mapserver.map
@@ -1,0 +1,47 @@
+MAP
+  NAME "GISNav OGC WMS"
+  PROJECTION
+    "init=epsg:4326"
+  END
+  EXTENT -122.3153963 37.4973779 -122.1845578 37.5650967
+  WEB
+    METADATA
+        "wms_title"           "GISNav WMS NAIP Imagery"
+        "wms_onlineresource"  "http://localhost:80/wms"
+        "wms_srs"             "EPSG:3857 EPSG:4326"
+        "wms_enable_request"  "GetMap GetCapabilities"
+    END
+  END
+  LAYER
+    NAME          "imagery"
+    DATA          "/etc/mapserver/naip.vrt"
+    TYPE RASTER
+    PROJECTION
+      "init=epsg:26910"
+    END
+  END
+  LAYER
+    NAME          "osm-buildings"
+    DATA          "/etc/mapserver/osm-buildings-ksql-airport.tif"
+    TYPE RASTER
+    PROJECTION
+      "init=epsg:4326"
+    END
+  END
+  LAYER
+    NAME          "usgs-dem"
+    DATA          "/etc/mapserver/USGS_13_n38w123_20220810.tif"
+    TYPE RASTER
+    PROJECTION
+      "init=epsg:4326"
+    END
+  END
+  LAYER
+    NAME          "osm-buildings-dem"
+    DATA          "/etc/mapserver/osm-buildings-dem.tif"
+    TYPE RASTER
+    PROJECTION
+      "init=epsg:4326"
+    END
+  END
+END

--- a/docker/mapserver/setup_mapserver.sh
+++ b/docker/mapserver/setup_mapserver.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+# Downloads NAIP imagery, OSM Buildings data, and creates a VRT file in the appropriate folder for the
+# camptocamp/mapserver Docker container.
+
+# Check that the NAIP map raster Google Drive link was provided
+if [ -z "$NAIP_GDOWN_ID" ]; then \
+  tput setaf 1; \
+  echo "\$NAIP_GDOWN_ID is empty! Provide it with --env NAIP_GDOWN_ID=\"url\"."; \
+  tput sgr0; \
+  exit 1; \
+fi
+
+cd /etc/mapserver
+
+# Install tools to download and unzip maps from Google Drive
+apt-get update && apt-get -y install unzip python3-pip wget
+pip3 install gdown
+
+# Download NAIP raster imagery
+NAIP_ZIP_FILENAME="usda-fsa-naip-san-mateo-ca-2020.zip"  # does not have to match uploaded file name
+if ! [ -f "$NAIP_ZIP_FILENAME" ]; then \
+  echo "Downloading NAIP imagery..."; \
+  gdown $NAIP_GDOWN_ID -O $NAIP_ZIP_FILENAME; \
+  unzip $NAIP_ZIP_FILENAME; \
+fi
+
+# Download OSM Buildings vector data if download ID given
+OSM_ZIP_FILENAME="osm-buildings-ksql-airport.zip"  # does not have to match uploaded file name
+if ! [ -z "$OSM_GDOWN_ID" ] && ! [ -f "$OSM_ZIP_FILENAME" ]; \
+  then \
+    echo "Downloading OSM Buildings data..."; \
+    gdown $OSM_GDOWN_ID -O $OSM_ZIP_FILENAME; \
+    unzip $OSM_ZIP_FILENAME; \
+  else \
+    echo "No download ID for OSM Buildings data provided or data already downloaded, skipping download."; \
+fi
+
+# Create VRT file from NAIP GeoTIFFs
+# VRT file name should match with what is configured in Mapfile
+VRT_FILENAME="naip.vrt"
+if ! [ -f "$VRT_FILENAME" ]; then \
+  echo "Creating VRT file."; \
+  gdalbuildvrt $VRT_FILENAME *.tif; \
+fi
+
+# Rasterize OSM Buildings vectors into a VRT file
+OSM_ZIP_FILENAME="osm-buildings-ksql-airport.zip"  # does not have to match uploaded file name
+OSM_TIF_FILENAME="osm-buildings-ksql-airport.tif"
+if ! [ -z "$OSM_GDOWN_ID" ] && ! [ -f "$OSM_TIF_FILENAME" ]; \
+  then \
+    echo "Rasterizing OSM Buildings data..."; \
+    gdal_rasterize -a height -ts $(gdalinfo $VRT_FILENAME |grep "Size is" |cut -d\  -f3-4 |sed "s/,//") \
+      osm-buildings-ksql-airport.geojson \
+      $OSM_TIF_FILENAME
+  else \
+    echo "No download ID for OSM Buildings data provided or raster already exists, skipping rasterization."; \
+fi
+
+# Download USGS DEM: https://www.sciencebase.gov/catalog/item/62f5de86d34eacf53973ab2a
+# Attribution: "Map services and data available from U.S. Geological Survey, National Geospatial Program."
+DEM_FILENAME="USGS_13_n38w123_20220810.tif"
+DEM_4326_FILENAME="USGS_13_n38w123_20220810__EPSG_4326.tif"
+if ! [ -f "$DEM_FILENAME" ]; \
+  then \
+    echo "Downloading digital elevation model (DEM)..."; \
+    wget "https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/13/TIFF/historical/n38w123/USGS_13_n38w123_20220810.tif"
+    cp $OSM_TIF_FILENAME $DEM_4326_FILENAME
+    gdalwarp $DEM_FILENAME $DEM_4326_FILENAME # -s_srs EPSG:4269 -t_srs EPSG:4326
+  else \
+    echo "Digital elevation model (DEM) already downloaded."; \
+fi
+
+# Calculate compound elevation layer as sum of OSM Buildings and USGS DEM (units are meters)
+# Assume DEM is low resolution enough to not model the buildings already included in OSM Buildings
+COMPOUND_FILENAME="osm-buildings-dem.tif"
+if [ -f "$DEM_4326_FILENAME" -a -f "$OSM_TIF_FILENAME" ] && ! [ -f "$COMPOUND_FILENAME" ]; \
+  then \
+    echo "Calculating compound elevation layer..."; \
+    gdal_calc.py -A $DEM_4326_FILENAME -B $OSM_TIF_FILENAME --outfile=$COMPOUND_FILENAME --calc="A+B" --extent=intersect
+  else \
+    echo "OSM Buildings or DEM missing, or compound layer already calculated."; \
+fi
+
+# Setup complete, start MapServer with default mapfile
+MS_MAPFILE=/etc/mapserver/mapserver.map
+export MS_MAPFILE
+/usr/local/bin/start-server

--- a/docker/mavros/Dockerfile
+++ b/docker/mavros/Dockerfile
@@ -1,0 +1,24 @@
+FROM ros:foxy
+
+LABEL maintainer="Harri Makelin <hmakelin@protonmail.com>"
+
+ARG USERNAME=gisnav
+ARG UID=1000
+ARG GID=$UID
+
+RUN apt-get update --fix-missing && \
+    apt-get install sudo && \
+    groupadd --gid $GID $USERNAME && useradd --uid $UID --gid $GID -m $USERNAME && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME
+USER $USERNAME
+
+RUN sudo apt-get -y install ros-foxy-mavros ros-foxy-mavros-extras && \
+    cd $HOME && \
+    wget https://raw.githubusercontent.com/mavlink/mavros/master/mavros/scripts/install_geographiclib_datasets.sh && \
+    sudo bash ./install_geographiclib_datasets.sh
+
+COPY * /
+RUN sudo chmod 755 /disable_shared_memory.xml
+
+CMD ros2 run mavros mavros_node --ros-args --param fcu_url:=udp-b://127.0.0.1:14551@14555
+#CMD ros2 run mavros mavros_node --ros-args --param fcu_url:=udp-b://127.0.0.1:14540@14550  # px4

--- a/docker/mavros/disable_shared_memory.xml
+++ b/docker/mavros/disable_shared_memory.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles" >
+    <transport_descriptors>
+        <transport_descriptor>
+            <transport_id>CustomUdpTransport</transport_id>
+            <type>UDPv4</type>
+        </transport_descriptor>
+    </transport_descriptors>
+    <participant profile_name="participant_profile" is_default_profile="true">
+        <rtps>
+            <userTransports>
+                <transport_id>CustomUdpTransport</transport_id>
+            </userTransports>
+            <useBuiltinTransports>false</useBuiltinTransports>
+        </rtps>
+    </participant>
+</profiles>

--- a/docker/px4/6011_typhoon_h480
+++ b/docker/px4/6011_typhoon_h480
@@ -1,0 +1,13 @@
+# SIMULATION USE ONLY
+# PX4 mock GPS SITL simulation demo default parameters
+param set-default NAV_ACC_RAD 20.0
+param set-default MPC_YAWRAUTO_MAX 22.5.0
+param set-default COM_POS_FS_DELAY 5
+param set-default COM_POS_FS_EPH 10
+param set-default EKF2_GPS_P_NOISE 10
+param set-default EKF2_GPS_P_GATE 7
+param set-default EKF2_GPS_V_NOISE 3
+param set-default SENS_GPS_MASK 4
+
+param set-default EKF2_GPS_CTRL 3
+param set-default EKF2_GPS_CHECK 12

--- a/docker/px4/Dockerfile
+++ b/docker/px4/Dockerfile
@@ -1,0 +1,53 @@
+FROM px4io/px4-dev-ros2-foxy
+
+LABEL maintainer="Harri Makelin <hmakelin@protonmail.com>"
+
+ARG USERNAME=gisnav
+ARG UID=1000
+ARG GID=$UID
+
+ARG ROS_DOMAIN_ID=0
+ENV ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
+
+# Set 'gisnav' as default user and add it to sudo'ers
+# QGroundControl will not run as 'root'
+RUN apt-get update --fix-missing && \
+    apt-get install sudo && \
+    groupadd --gid $GID $USERNAME && useradd --uid $UID --gid $GID -m $USERNAME && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME
+USER $USERNAME
+
+# gstreamer and Gazebo plugins for getting video stream out of gazebo
+RUN sudo apt-get -y install ros-foxy-gazebo-ros-pkgs gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl
+
+# Install PX4-Autopilot, pull latest commit from PX4-SITL_gazebo submodule fork
+RUN sudo apt-get -y install -o Dpkg::Options::="--force-overwrite" \
+        libignition-common3-core-dev libignition-common3-av-dev expect && \
+    git clone --branch hmakelin-v1.14.0-beta1 \
+        https://github.com/hmakelin/PX4-Autopilot.git $HOME/PX4-Autopilot --recursive && \
+    cd $HOME/PX4-Autopilot && \
+    git fetch --all --tags && \
+    git checkout tags/v1.14.0-1.0.1-beta1 -b gisnav && \
+    git submodule update --init --recursive && \
+    cd Tools/simulation/gazebo/sitl_gazebo && \
+    git pull origin hmakelin-v1.14.0-beta1 && \
+    cd $HOME/PX4-Autopilot && \
+    bash Tools/setup/ubuntu.sh --no-nuttx
+
+# Make initial PX4 build (for faster startup in the future)
+RUN cd $HOME/PX4-Autopilot && \
+    yes | DONT_RUN=1 make px4_sitl gazebo_typhoon_h480__ksql_airport
+
+# Apply configuration files
+COPY * /
+RUN sudo mv -t $HOME/ /6011_typhoon_h480 && \
+    cat $HOME/6011_typhoon_h480 >> $HOME/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/airframes/6011_typhoon_h480
+
+# Run SITL simulation - answer 'y' to prompt about custom commit in submodule
+CMD cd ${HOME}/PX4-Autopilot && \
+	expect -c \
+		"set timeout -1; \
+		spawn make HEADLESS=${GAZEBO_HEADLESS} px4_sitl gazebo_typhoon_h480__ksql_airport; \
+		expect \"Hit 'y' and <ENTER> to continue the build with this version. Hit <ENTER> to resolve manually.\"; \
+		send \"y\n\"; \
+		interact"

--- a/docker/qgc/Dockerfile
+++ b/docker/qgc/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:focal
+
+LABEL maintainer="Harri Makelin <hmakelin@protonmail.com>"
+
+ARG USERNAME=qgroundcontrol
+ARG UID=1000
+ARG GID=$UID
+
+RUN apt-get update --fix-missing && \
+    apt-get install sudo && \
+    groupadd --gid $GID $USERNAME && useradd --uid $UID --gid $GID -m $USERNAME && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME
+USER $USERNAME
+
+RUN sudo apt-get update --fix-missing && \
+    sudo usermod -a -G dialout $USERNAME && \
+    sudo apt-get remove modemmanager -y && \
+    sudo apt-get -y install gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl && \
+    sudo apt-get -y install libqt5gui5 && \
+    sudo apt-get -y install libfuse2 && \
+    sudo apt-get -y install libpulse-mainloop-glib0  && \
+    sudo apt-get -y install wget
+
+RUN wget -P $HOME https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.AppImage && \
+    sudo chmod +x $HOME/QGroundControl.AppImage
+
+COPY * /
+RUN sudo mv -t $HOME/ /ksql_airport_px4.plan /ksql_airport_ardupilot.plan
+
+ENTRYPOINT ["/bin/bash", "-c", "cd $HOME && ./QGroundControl.AppImage --appimage-extract-and-run"]

--- a/docker/qgc/ksql_airport_ardupilot.plan
+++ b/docker/qgc/ksql_airport_ardupilot.plan
@@ -1,0 +1,178 @@
+{
+    "fileType": "Plan",
+    "geoFence": {
+        "circles": [
+        ],
+        "polygons": [
+        ],
+        "version": 2
+    },
+    "groundStation": "QGroundControl",
+    "mission": {
+        "cruiseSpeed": 15,
+        "firmwareType": 3,
+        "globalPlanAltitudeMode": 1,
+        "hoverSpeed": 5,
+        "items": [
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 120,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 22,
+                "doJumpId": 1,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.5236399,
+                    -122.255122,
+                    120
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 120,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 2,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.52357273,
+                    -122.25343769,
+                    120
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "autoContinue": true,
+                "command": 205,
+                "doJumpId": 3,
+                "frame": 2,
+                "params": [
+                    -85,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    2
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 120,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 4,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.52214495,
+                    -122.25349272,
+                    120
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 120,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 5,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.52232576,
+                    -122.25688879,
+                    120
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 120,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 6,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.52463888,
+                    -122.25685734,
+                    120
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 120,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 7,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.5250566,
+                    -122.25515145,
+                    120
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "autoContinue": true,
+                "command": 20,
+                "doJumpId": 8,
+                "frame": 2,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "type": "SimpleItem"
+            }
+        ],
+        "plannedHomePosition": [
+            37.5236399,
+            -122.255122,
+            2.7472013120475456
+        ],
+        "vehicleType": 2,
+        "version": 2
+    },
+    "rallyPoints": {
+        "points": [
+        ],
+        "version": 2
+    },
+    "version": 1
+}

--- a/docker/qgc/ksql_airport_px4.plan
+++ b/docker/qgc/ksql_airport_px4.plan
@@ -1,0 +1,194 @@
+{
+    "fileType": "Plan",
+    "geoFence": {
+        "circles": [
+        ],
+        "polygons": [
+        ],
+        "version": 2
+    },
+    "groundStation": "QGroundControl",
+    "mission": {
+        "cruiseSpeed": 15,
+        "firmwareType": 12,
+        "globalPlanAltitudeMode": 1,
+        "hoverSpeed": 5,
+        "items": [
+            {
+                "autoContinue": true,
+                "command": 530,
+                "doJumpId": 1,
+                "frame": 2,
+                "params": [
+                    0,
+                    2,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "autoContinue": true,
+                "command": 205,
+                "doJumpId": 2,
+                "frame": 2,
+                "params": [
+                    -85,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    2
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": 130,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 22,
+                "doJumpId": 3,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.5236489,
+                    -122.2551101,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": 130,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 4,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.52371697,
+                    -122.25300218,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": 130,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 5,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.52176837,
+                    -122.2531202,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": 130,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 6,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.52190452,
+                    -122.25684311,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": 130,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 7,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.52347872,
+                    -122.25807692,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": 130,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 8,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.52461893,
+                    -122.25681092,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "autoContinue": true,
+                "command": 20,
+                "doJumpId": 9,
+                "frame": 2,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "type": "SimpleItem"
+            }
+        ],
+        "plannedHomePosition": [
+            37.5236489,
+            -122.2551101,
+            2.673999185660817
+        ],
+        "vehicleType": 2,
+        "version": 2
+    },
+    "rallyPoints": {
+        "points": [
+        ],
+        "version": 2
+    },
+    "version": 1
+}

--- a/docs/pages/developer_guide/index.rst
+++ b/docs/pages/developer_guide/index.rst
@@ -12,6 +12,7 @@ it to match your use case.
     :caption: Setup SITL environment
 
     sitl_environment/prerequisites
+    sitl_environment/docker
     sitl_environment/autopilot
     sitl_environment/qgroundcontrol
     sitl_environment/gis_server

--- a/docs/pages/developer_guide/index.rst
+++ b/docs/pages/developer_guide/index.rst
@@ -11,7 +11,6 @@ it to match your use case.
 .. toctree::
     :caption: Setup SITL environment
 
-    sitl_environment/docker
     sitl_environment/prerequisites
     sitl_environment/autopilot
     sitl_environment/qgroundcontrol

--- a/docs/pages/developer_guide/integrate/ros_messaging.rst
+++ b/docs/pages/developer_guide/integrate/ros_messaging.rst
@@ -65,7 +65,7 @@ You can see the subscribed topic names and message types in the ``__init__`` met
 
 .. note::
     See :ref:`Remapping ROS 2 topics` to adapt these nodes to your system. For example, you must remap the PX4 topic
-    names from ``fmu/*/out`` to ``fmu/out/*`` if you are using PX4 v1.14.0-beta1 instead of v1.13.X.
+    names from  ``fmu/out/*`` to ``fmu/*/out`` if you are using PX4 v1.13.X instead of v1.14.0-beta1.
 
     .. _name remapping: https://design.ros2.org/articles/static_remapping.html
 

--- a/docs/pages/developer_guide/sitl_environment/autopilot.rst
+++ b/docs/pages/developer_guide/sitl_environment/autopilot.rst
@@ -34,6 +34,18 @@ vicinity of San Carlos (KSQL) airport:
     .. tab-item:: v1.14.0-beta1
         :selected:
 
+        .. note::
+            You must `create the micro-ros-agent`_ for the following command to work
+
+        .. _create the micro-ros-agent: https://micro.ros.org/docs/tutorials/core/first_application_linux/
+
+        .. code-block:: bash
+            :caption: Run ``micro-ros-agent``
+
+            cd ~/colcon_ws
+            ros2 run micro_ros_agent micro_ros_agent udp4 --port 8888
+
+
         .. code-block:: bash
             :caption: Run PX4 Gazebo SITL simulation at KSQL airport
 

--- a/docs/pages/developer_guide/sitl_environment/docker.md
+++ b/docs/pages/developer_guide/sitl_environment/docker.md
@@ -1,0 +1,185 @@
+# GISNav SITL Simulation Environment
+
+The `docker` folder contains scripts for generating SITL simulation environments for development, testing and 
+demonstration. 
+
+The `docker-compose.yaml` file defines the following services:
+
+* `ardupilot`
+  * ArduPilot Gazebo SITL simulation
+  * Starts `gazebo-iris` model with added static down (FRD frame) facing camera at
+    KSQL Airport
+* `px4`
+  * PX4 Gazebo SITL simulation
+  * Starts `typhoon_h480` model at KSQL Airport
+* `mavros`
+  * Used for ArduPilot SITL
+* `micro_ros_agent`
+  * Used for PX4 SITL
+* `mapserver`
+  * WMS server with self-hosted [NAIP][2] and [OSM Buildings][3] data covering KSQL airport  
+* `mapproxy`
+  * WMS proxy for existing remote tile-based imagery endpoint. Alternative for `mapserver` when imagery layer needs to cover multiple flight regions (over presumedly multiple test scenarios covering too large an area to self-host).
+* `gisnav`
+  * GISNav ROS 2 package for demo purposes
+  * Launches GISNav with PX4 configuration by default. Intended to be used with `px4` service, but 
+    Docker command can be changed to launch for `ardupilot`.
+
+[1]: https://github.com/hmakelin/gisnav
+[2]: https://en.wikipedia.org/wiki/National_Agriculture_Imagery_Program
+[3]: https://osmbuildings.org/
+
+## Prerequisites
+You must install [docker][4] and the [docker compose plugin][5] to run these example commands.
+
+[4]: https://docs.docker.com/engine/install/
+[5]: https://docs.docker.com/compose/install/linux/
+
+If you have an NVIDIA GPU on your host machine, ensure you have [NVIDIA Container Toolkit installed][6].
+
+[6]: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+
+
+## PX4 SITL (Mock GPS Demo)
+
+Follow these instructions to launch the SITL simulation used in the [mock GPS demo][7].
+
+> **Note** Run the below commands without the `gisnav` service if you want to develop or test a local copy of `gisnav`
+
+[7]: https://github.com/hmakelin/gisnav/blob/master/README.md#mock-gps-example
+
+### Clone
+
+Clone this repository and change to its root directory:
+
+```bash
+cd $HOME
+git clone https://github.com/hmakelin/gisnav-docker.git
+cd gisnav-docker
+```
+
+### Build
+
+To build the `mapserver`, `px4`,  `micro-ros-agent`, and `gisnav` services by running the following command:
+
+```bash
+docker compose build mapserver px4 micro-ros-agent qgc gisnav
+```
+
+### Run
+
+Run the PX4 SITL simulation with GISNav:
+
+```bash
+docker compose up mapserver px4 micro-ros-agent qgc gisnav
+```
+
+### Shutdown
+
+```bash
+docker-compose down
+```
+
+## ArduPilot SITL
+
+Build and run the SITL simulation environment with ArduPilot instead of PX4:
+
+### Build
+```bash
+docker compose \
+  -f docker-compose.yaml \
+  -f docker-compose.ardupilot.yaml \
+  build mapserver ardupilot mavros qgc
+```
+
+### Run
+```bash
+docker compose \
+  -f docker-compose.yaml \
+  -f docker-compose.ardupilot.yaml \
+  up mapserver ardupilot mavros qgc
+```
+
+## Mapproxy
+
+Run the SITL simulation with a WMS proxy instead of locally hosted maps:
+
+> **Note**
+> Replace the example `MAPPROXY_TILE_URL` string below with your own tile-based endpoint url (e.g. WMTS). See
+> [MapProxy configuration examples][8] for more information on how to format the string.
+
+[8]: https://mapproxy.org/docs/latest/configuration_examples.html
+
+```bash
+docker-compose build \
+  --build-arg MAPPROXY_TILE_URL="https://<your-map-server-url>/tiles/%(z)s/%(y)s/%(x)s" \
+  mapproxy px4 micro-ros-agent gisnav
+docker compose up mapproxy px4 micro-ros-agent qgc
+```
+
+## Troubleshooting
+
+### Expose `xhost`
+
+If the Gazebo and QGroundControl windows do not appear on your screen soon after running your container you may need to 
+expose your ``xhost`` to your Docker container as described in the [ROS GUI Tutorial][9]:
+
+[9]: http://wiki.ros.org/docker/Tutorials/GUI
+
+```bash
+export containerId=$(docker ps -l -q)
+xhost +local:$(docker inspect --format='{{ .Config.Hostname }}' $containerId)
+```
+
+### Headless mode
+
+You may want to run Gazebo in headless mode when doing automated testing ([e.g. with mavsdk][10]):
+
+[10]: https://github.com/hmakelin/gisnav/blob/master/test/sitl/sitl_test_mock_gps_node.py
+
+```bash
+GAZEBO_HEADLESS=1 docker compose up px4
+```
+
+### Disable SharedMemory for Fast DDS
+
+> [RTPS_TRANSPORT_SHM Error] Failed init_port fastrtps_port7412: open_and_lock_file failed -> Function 
+> open_port_internal
+
+If you are not able to establish ROS communication between the `mavros` or `micro-ros-agent` container and the host, or 
+receive the above error when using `--network host`, try disabling SharedMemory for Fast DDS **on your host**. You can
+do so by creating an XML configuration (e.g. `disable_shared_memory.xml`) as described in [this comment][11] or 
+discussion [here][12] and restarting ROS 2 daemon with the new configuration:
+
+[11]: https://github.com/eProsima/Fast-DDS/issues/1698#issuecomment-778039676
+[12]: https://stackoverflow.com/questions/65900201/troubles-communicating-with-ros2-node-in-docker-container
+
+```bash
+export FASTRTPS_DEFAULT_PROFILES_FILE=disable_fastrtps.xml
+ros2 daemon stop
+ros2 daemon start
+```
+
+### Disable AppArmor for ArduPilot SITL
+
+**Caution advised**: Possibly needed if using `--network host`: If QGroundControl or Gazebo do not seem to be starting 
+when running the containers, you may need to run them image with `--security-opt apparmor:unconfined` or `--privileged` 
+options.
+
+### Run shell inside container
+
+If you need to do debugging on the images with GUI applications enabled (e.g. Gazebo inside `px4`), you can use the 
+following command to run bash inside the container:
+
+```bash
+docker run -it \
+  --env="DISPLAY" \
+  --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+  --volume "/dev/shm:/dev/shm" \
+  --volume="/dev/dri:/dev/dri" \
+  --gpus all \
+  --tty \
+  --network host \
+  --entrypoint="/bin/bash" \
+  gisnav-docker-px4
+```

--- a/docs/pages/developer_guide/sitl_environment/docker.md
+++ b/docs/pages/developer_guide/sitl_environment/docker.md
@@ -48,16 +48,6 @@ Follow these instructions to launch the SITL simulation used in the [mock GPS de
 
 [7]: https://github.com/hmakelin/gisnav/blob/master/README.md#mock-gps-example
 
-### Clone
-
-Clone this repository and change to its root directory:
-
-```bash
-cd $HOME
-git clone https://github.com/hmakelin/gisnav-docker.git
-cd gisnav-docker
-```
-
 ### Build
 
 To build the `mapserver`, `px4`,  `micro-ros-agent`, and `gisnav` services by running the following command:
@@ -162,6 +152,11 @@ ros2 daemon start
 
 ### Disable AppArmor for ArduPilot SITL
 
+> dbus[33]: The last reference on a connection was dropped without closing the connection. This is a bug in an 
+> application. See dbus_connection_unref() documentation for details. Most likely, the application was supposed to call 
+> dbus_connection_close(), since this is a private connection. D-Bus not built with -rdynamic so unable to print a 
+> backtrace
+
 **Caution advised**: Possibly needed if using `--network host`: If QGroundControl or Gazebo do not seem to be starting 
 when running the containers, you may need to run them image with `--security-opt apparmor:unconfined` or `--privileged` 
 options.
@@ -181,5 +176,5 @@ docker run -it \
   --tty \
   --network host \
   --entrypoint="/bin/bash" \
-  gisnav-docker-px4
+  gisnav-px4
 ```

--- a/docs/pages/developer_guide/sitl_environment/docker.rst
+++ b/docs/pages/developer_guide/sitl_environment/docker.rst
@@ -1,0 +1,5 @@
+Docker
+______________________________________________________
+
+.. include:: ./docker.md
+    :parser: myst_parser.sphinx_

--- a/docs/pages/developer_guide/sitl_environment/docker.rst
+++ b/docs/pages/developer_guide/sitl_environment/docker.rst
@@ -1,9 +1,0 @@
-Docker
-____________________________________________________
-`Dockerized environments <https://github.com/hmakelin/gisnav-docker>`_ are available. Take a look at the
-Dockerfiles to see how everything is set up. These instructions should closely mirror what is included in the
-Dockerfiles with only minor differences.
-
-You can also take a look at the prebuilt `sitl <https://hub.docker.com/r/hmakelin/gisnav-sitl>`_ and `mapserver
-<https://hub.docker.com/r/hmakelin/gisnav-mapserver>`_ images available in Docker Hub in case you have problems with
-the build process.

--- a/gisnav/nodes/map_node.py
+++ b/gisnav/nodes/map_node.py
@@ -104,6 +104,9 @@ class MapNode(CameraSubscriberNode):
     ROS_D_MAP_OVERLAP_UPDATE_THRESHOLD = 0.85
     """Overlap ration between FOV and current map, under which a new map will be requested."""
 
+    ROS_D_MAX_MAP_RADIUS = 1000
+    """Max radius for circle inside the maps (half map side length)"""
+
     ROS_D_MAP_UPDATE_UPDATE_DELAY = 1
     """Default delay in seconds for throttling WMS GetMap requests
     
@@ -139,6 +142,7 @@ class MapNode(CameraSubscriberNode):
         ('transparency', ROS_D_IMAGE_TRANSPARENCY, False),
         ('format', ROS_D_IMAGE_FORMAT, False),
         ('map_overlap_update_threshold', ROS_D_MAP_OVERLAP_UPDATE_THRESHOLD, False),
+        ('max_map_radius', ROS_D_MAX_MAP_RADIUS, False),
     ]
     """List containing ROS parameter name, default value and read_only flag tuples"""
 

--- a/gisnav/nodes/map_node.py
+++ b/gisnav/nodes/map_node.py
@@ -45,7 +45,7 @@ class MapNode(CameraSubscriberNode):
         ``requests``. They are therefore handled as unexpected errors.
     """
 
-    ROS_D_URL = 'http://localhost:80/wms'
+    ROS_D_URL = 'http://127.0.0.1:80/wms'
     """Default WMS URL"""
 
     ROS_D_VERSION = '1.3.0'

--- a/gisnav/nodes/messaging.py
+++ b/gisnav/nodes/messaging.py
@@ -49,7 +49,7 @@ ROS_TOPIC_EGM96_HEIGHT = 'gisnav/egm96_height'
 ROS_TOPIC_GPS_INPUT = '/mavros/gps_input/gps_input'
 """Name of ROS topic for outgoing :class:`mavros_msgs.msg.GPSINPUT` messages over MAVROS"""
 
-ROS_TOPIC_SENSOR_GPS = '/fmu/sensor_gps/in'
+ROS_TOPIC_SENSOR_GPS = '/fmu/in/sensor_gps'
 """Name of ROS topic for outgoing :class:`px4_msgs.msg.SensorGps` messages over PX4 microRTPS bridge"""
 # endregion ROS topic names
 

--- a/gisnav/nodes/mock_gps_node.py
+++ b/gisnav/nodes/mock_gps_node.py
@@ -212,7 +212,6 @@ class MockGPSNode(BaseNode):
         msg.cog_rad = np.nan
         msg.vel_ned_valid = False
         msg.timestamp_time_relative = 0
-        msg.time_utc_usec = int(time.time() * 1e6)
         msg.satellites_used = np.iinfo(np.uint8).max
         msg.time_utc_usec = int(time.time() * 1e6)
         msg.heading = heading

--- a/gisnav/nodes/mock_gps_node.py
+++ b/gisnav/nodes/mock_gps_node.py
@@ -186,12 +186,12 @@ class MockGPSNode(BaseNode):
         :param timestamp: System time in microseconds
         """
         msg = SensorGps()
-        msg.timestamp = timestamp
-        msg.timestamp_sample = 0
+        msg.timestamp = int(time.time_ns() / 1e3) #timestamp
+        msg.timestamp_sample = int(timestamp)
         # msg.device_id = self._generate_device_id()
         msg.device_id = 0
         msg.fix_type = 3
-        msg.s_variance_m_s = np.nan
+        msg.s_variance_m_s = 10.0 #np.nan
         msg.c_variance_rad = np.nan
         msg.lat = int(lat * 1e7)
         msg.lon = int(lon * 1e7)
@@ -205,18 +205,18 @@ class MockGPSNode(BaseNode):
         msg.automatic_gain_control = 0
         msg.jamming_state = 0
         msg.jamming_indicator = 0
-        msg.vel_m_s = np.nan
-        msg.vel_n_m_s = np.nan
-        msg.vel_e_m_s = np.nan
-        msg.vel_d_m_s = np.nan
+        msg.vel_m_s = 0. #np.nan
+        msg.vel_n_m_s = 0. #np.nan
+        msg.vel_e_m_s = 0. #np.nan
+        msg.vel_d_m_s = 0. #np.nan
         msg.cog_rad = np.nan
-        msg.vel_ned_valid = False
+        msg.vel_ned_valid = True #False
         msg.timestamp_time_relative = 0
         msg.satellites_used = np.iinfo(np.uint8).max
-        msg.time_utc_usec = int(time.time() * 1e6)
+        msg.time_utc_usec = msg.timestamp
         msg.heading = heading
-        msg.heading_offset = np.nan
-        # msg.heading_accuracy = np.nan
+        msg.heading_offset = 0. #np.nan
+        msg.heading_accuracy = np.nan
         # msg.rtcm_injection_rate = np.nan
         # msg.selected_rtcm_instance = np.nan
 

--- a/gisnav/nodes/px4_node.py
+++ b/gisnav/nodes/px4_node.py
@@ -36,22 +36,22 @@ class PX4Node(AutopilotNode):
 
         self._vehicle_global_position = None
         self._vehicle_global_position_sub = self.create_subscription(VehicleGlobalPosition,
-                                                                     '/fmu/vehicle_global_position/out',
+                                                                     '/fmu/out/vehicle_global_position',
                                                                      self._vehicle_global_position_callback,
                                                                      QoSPresetProfiles.SENSOR_DATA.value)
         self._vehicle_local_position = None
         self._vehicle_local_position_sub = self.create_subscription(VehicleLocalPosition,
-                                                                    '/fmu/vehicle_local_position/out',
+                                                                    '/fmu/out/vehicle_local_position',
                                                                     self._vehicle_local_position_callback,
                                                                     QoSPresetProfiles.SENSOR_DATA.value)
         self._vehicle_attitude = None
         self._vehicle_attitude_sub = self.create_subscription(VehicleAttitude,
-                                                              '/fmu/vehicle_attitude/out',
+                                                              '/fmu/out/vehicle_attitude',
                                                               self._vehicle_attitude_callback,
                                                               QoSPresetProfiles.SENSOR_DATA.value)
         self._gimbal_device_set_attitude = None
         self._gimbal_device_set_attitude_sub = self.create_subscription(GimbalDeviceSetAttitude,
-                                                                        '/fmu/gimbal_device_set_attitude/out',
+                                                                        '/fmu/out/gimbal_device_set_attitude',
                                                                         self._gimbal_device_set_attitude_callback,
                                                                         QoSPresetProfiles.SENSOR_DATA.value)
 

--- a/gisnav/pose_estimators/__init__.py
+++ b/gisnav/pose_estimators/__init__.py
@@ -10,5 +10,13 @@ package namespace for convenience. For example:
 """
 from .pose_estimator import PoseEstimator
 from .keypoint_pose_estimator import KeypointPoseEstimator
-from .superglue_pose_estimator import SuperGluePoseEstimator
-from .loftr_pose_estimator import LoFTRPoseEstimator
+try:
+    from .superglue_pose_estimator import SuperGluePoseEstimator
+except ModuleNotFoundError as e:
+    # Submodule not loaded
+    pass
+try:
+    from .loftr_pose_estimator import LoFTRPoseEstimator
+except ModuleNotFoundError as e:
+    # Submodule not loaded
+    pass

--- a/launch/params/map_node.yaml
+++ b/launch/params/map_node.yaml
@@ -1,6 +1,6 @@
 map_node:
   ros__parameters:
-    url: 'http://localhost:80/wms'
+    url: 'http://127.0.0.1:80/wms'
     layers: ['imagery']
     dem_layers: ['osm-buildings']
     # srs: 'EPSG:4326'  # default value, disabled for testing purposes

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>gisnav</name>
-  <version>0.63.1</version>
+  <version>0.64.0</version>
   <description>Estimates airborne drone global position by matching video to map retrieved from onboard GIS server.</description>
   <author email="hmakelin@protonmail.com">Harri Makelin</author>
   <maintainer email="hmakelin@protonmail.com">Harri Makelin</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>gisnav</name>
-  <version>0.63.0</version>
+  <version>0.63.1</version>
   <description>Estimates airborne drone global position by matching video to map retrieved from onboard GIS server.</description>
   <author email="hmakelin@protonmail.com">Harri Makelin</author>
   <maintainer email="hmakelin@protonmail.com">Harri Makelin</maintainer>

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ pyyaml
 requests
 
 # Geospatial objects handling
-geopandas
-shapely
-pyproj
+geopandas==0.12.2
+shapely==1.8.2
+pyproj==3.2.1
 
 # Used by LoFTR
 einops

--- a/test/launch/test_px4_launch.py
+++ b/test/launch/test_px4_launch.py
@@ -58,11 +58,11 @@ class TestPX4Launch(unittest.TestCase):
     """List of camera topic names and types"""
 
     AUTOPILOT_TOPIC_NAMES_AND_TYPES = [
-        ('/fmu/vehicle_global_position/out', VehicleGlobalPosition),
-        ('/fmu/vehicle_local_position/out', VehicleLocalPosition),
-        ('/fmu/vehicle_attitude/out', VehicleAttitude),
-        ('/fmu/gimbal_device_set_attitude/out', GimbalDeviceSetAttitude),
-        ('/fmu/sensor_gps/in', SensorGps)
+        ('/fmu/out/vehicle_global_position', VehicleGlobalPosition),
+        ('/fmu/out/vehicle_local_position', VehicleLocalPosition),
+        ('/fmu/out/vehicle_attitude', VehicleAttitude),
+        ('/fmu/out/gimbal_device_set_attitude', GimbalDeviceSetAttitude),
+        ('/fmu/in/sensor_gps', SensorGps)
     ]
     """List of autopilot topic names and types"""
 


### PR DESCRIPTION
- Moves https://github.com/hmakelin/gisnav-docker.git repository contents to `docker` folder and updates `README.md` accordingly
  - Earlier `sitl` service has been broken down into smaller specialized services (`qgc`, `px4`, `ardupilot`, `micro-ros-agent`, `mavros`, `gisnav`)
- Updates default topic names for `PX4Node` for PX4 v1.14(.0-beta1)
- Adds missing instruction on `micro-ros-agent` to Sphinx docs
- A number of smaller bug fixes
- Update version to v0.64.0