### PR TITLE
Add display env variable for gisnav service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,6 +55,8 @@ services:
       context: docker/gisnav
       dockerfile: Dockerfile
     environment:
+      - QT_X11_NO_MITSHM=1
+      - DISPLAY=${DISPLAY}
       - FASTRTPS_DEFAULT_PROFILES_FILE=/disable_shared_memory.xml
     volumes:
       - /dev/dri:/dev/dri


### PR DESCRIPTION
Enables drawing field of view match for pose estimation node inside gisnav (docker) service