### PR TITLE
Fixes for Jetson Nano build

### DIFF
--- a/docker-compose.arm64.yaml
+++ b/docker-compose.arm64.yaml
@@ -1,0 +1,5 @@
+version: "3.4"
+
+services:
+  mapserver:
+    image: camptocamp/mapserver:latest-arm64

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,7 +70,10 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [ gpu ]
-    command: bash -c "source /opt/ros/foxy/setup.bash && source ~/colcon_ws/install/setup.bash && ros2 launch gisnav px4.launch.py"
+    command: >
+      bash -c "source /opt/ros/foxy/setup.bash && source ~/colcon_ws/install/setup.bash &&
+      export LD_PRELOAD=$(find $(pip3 show torch |grep Location:  |cut -d' ' -f 2)/torch/lib -name 'libgomp*') &&
+      ros2 launch gisnav px4.launch.py"
 
   px4:
     build:

--- a/docker/gisnav/Dockerfile
+++ b/docker/gisnav/Dockerfile
@@ -11,7 +11,9 @@ RUN apt-get update --fix-missing && \
 USER $USERNAME
 
 # Install GDAL
-RUN sudo apt-get -y install software-properties-common && \
+RUN sudo apt-get -y upgrade && \
+    sudo apt-get -y update && \
+    sudo apt-get -y install software-properties-common && \
     sudo add-apt-repository ppa:ubuntugis/ppa && \
     sudo apt-get update && \
     sudo apt-get -y install gdal-bin libgdal-dev

--- a/docker/gisnav/Dockerfile
+++ b/docker/gisnav/Dockerfile
@@ -10,6 +10,12 @@ RUN apt-get update --fix-missing && \
     echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME
 USER $USERNAME
 
+# Install GDAL
+RUN sudo apt-get -y install software-properties-common && \
+    sudo add-apt-repository ppa:ubuntugis/ppa && \
+    sudo apt-get update && \
+    sudo apt-get -y install gdal-bin libgdal-dev
+
 # Install GISNav & colcon dependencies
 RUN mkdir -p $HOME/colcon_ws/src && \
     cd $HOME/colcon_ws/src && \

--- a/docker/gisnav/Dockerfile
+++ b/docker/gisnav/Dockerfile
@@ -10,14 +10,6 @@ RUN apt-get update --fix-missing && \
     echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME
 USER $USERNAME
 
-# Install GDAL
-RUN sudo apt-get -y upgrade && \
-    sudo apt-get -y update && \
-    sudo apt-get -y install software-properties-common && \
-    sudo add-apt-repository ppa:ubuntugis/ppa && \
-    sudo apt-get update && \
-    sudo apt-get -y install gdal-bin libgdal-dev
-
 # Install GISNav & colcon dependencies
 RUN mkdir -p $HOME/colcon_ws/src && \
     cd $HOME/colcon_ws/src && \
@@ -35,6 +27,14 @@ RUN cd $HOME/colcon_ws/src/gisnav && \
     mkdir weights && \
     cd weights && \
     $HOME/.local/lib/$USERNAME/gdown https://drive.google.com/uc?id=1M-VD35-qdB5Iw-AtbDBCKC7hPolFW9UY
+
+# Install GDAL
+RUN sudo apt-get -y upgrade && \
+    sudo apt-get -y update && \
+    sudo apt-get -y install software-properties-common && \
+    sudo add-apt-repository ppa:ubuntugis/ppa && \
+    sudo apt-get update && \
+    sudo apt-get -y install gdal-bin libgdal-dev \
 
 # Python dependencies
 RUN cd $HOME/colcon_ws/src/gisnav && \

--- a/docs/pages/developer_guide/sitl_environment/docker.md
+++ b/docs/pages/developer_guide/sitl_environment/docker.md
@@ -14,7 +14,7 @@ The `docker-compose.yaml` file defines the following services:
   * Starts `typhoon_h480` model at KSQL Airport
 * `mavros`
   * Used for ArduPilot SITL
-* `micro_ros_agent`
+* `micro-ros-agent`
   * Used for PX4 SITL
 * `mapserver`
   * WMS server with self-hosted [NAIP][2] and [OSM Buildings][3] data covering KSQL airport  

--- a/docs/pages/developer_guide/sitl_environment/install_gisnav.rst
+++ b/docs/pages/developer_guide/sitl_environment/install_gisnav.rst
@@ -26,6 +26,18 @@ ROS version with the ``whereis ros2`` command:
         echo "source /opt/ros/foxy/setup.bash" >> ~/.bashrc
         echo "source ~/colcon_ws/install/setup.bash" >> ~/.bashrc
 
+Install GDAL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``GDAL`` is required to install the ``geopandas`` Python dependency:
+
+.. code-block:: text
+    :caption: Install GDAL
+
+    sudo apt-get -y install software-properties-common
+    sudo add-apt-repository ppa:ubuntugis/ppa
+    sudo apt-get update
+    sudo apt-get -y install gdal-bin libgdal-dev
+
 Install GISNav
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Install GISNav in your ROS 2 Workspace:


### PR DESCRIPTION
Small fixes to make `gisnav` and `mapserver` services work on e.g. a Jetson Nano:
* Install GDAL separately for `gisnav` docker image: fixes potential error when installing geopandas later on (see e.g. https://stackoverflow.com/questions/62299567/error-installing-geopandas-a-gdal-api-version-must-be-specified-in-visual-st)
* Preload `libgomp` for `gisnav` docker image
* Add `arm64` docker compose override for `mapserver` docker image
* Documentation updates