### PR TITLE
Update SITL tests & fix WMS connection

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -19,5 +19,6 @@ jobs:
     steps:
       - name: Run pre-commit
         run: |
+          export PATH=$(python3 -m site --user-base)/lib/gisnav:$PATH
           cd /home/gisnav/colcon_ws/src/gisnav
           pre-commit run --all-files

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
     network_mode: host
     environment:
       - ROS_DOMAIN_ID=0
+      - FASTRTPS_DEFAULT_PROFILES_FILE=/disable_shared_memory.xml
     volumes:
       - /dev/shm:/dev/shm
     command: udp4 -p 8888
@@ -67,7 +68,7 @@ services:
     env_file:
       - .env/.x11.env
     environment:
-      - FASTRTPS_DEFAULT_PROFILES_FILE=~/colcon_ws/src/gisnav/docker/gisnav/disable_shared_memory.xml
+      - FASTRTPS_DEFAULT_PROFILES_FILE=/home/gisnav/colcon_ws/src/gisnav/docker/gisnav/disable_shared_memory.xml
     volumes:
       - /dev/dri:/dev/dri
     network_mode: host

--- a/docker/gisnav/Dockerfile
+++ b/docker/gisnav/Dockerfile
@@ -14,6 +14,8 @@ USER $USERNAME
 
 WORKDIR /home/$USERNAME/colcon_ws/src/gisnav
 COPY --chown=$USERNAME . .
+ENV FASTRTPS_DEFAULT_PROFILES_FILE \
+/home/$USERNAME/colcon_ws/src/gisnav/docker/gisnav/disable_shared_memory.xml
 
 RUN sudo chmod +x docker/gisnav/entrypoint.sh
 

--- a/gisnav/nodes/map_node.py
+++ b/gisnav/nodes/map_node.py
@@ -240,6 +240,7 @@ class MapNode(CameraSubscriberNode):
             try:
                 self.get_logger().error("Connecting to WMS endpoint...")
                 self._wms_client = WebMapService(url, version=version, timeout=timeout)
+                self.connected = True
             except requests.exceptions.ConnectionError as _:  # noqa: F841
                 self.get_logger().error(
                     f"Could not connect to WMS endpoint, trying again in "
@@ -247,7 +248,9 @@ class MapNode(CameraSubscriberNode):
                 )
                 time.sleep(self._WMS_CONNECTION_ATTEMPT_DELAY)
 
-        self.connected = True
+        # TODO: any other errors that might prevent connection?
+        #  handle disconnect & reconnect
+        assert self.connected
         self.get_logger().info("WMS client setup complete.")
 
     # region Properties

--- a/test/sitl/sitl_test_mock_gps_node.py
+++ b/test/sitl/sitl_test_mock_gps_node.py
@@ -132,8 +132,8 @@ def setup():
     This most likely means starting supporting services with docker
     """
     print("Starting SITL environment...")
-    os.system("make -C docker up-offboard-sitl-test-px4")
     os.system("docker compose -f docker/docker-compose.yaml up -d gisnav")
+    os.system("make -C docker up-offboard-sitl-test-px4")
 
 
 def cleanup():

--- a/test/sitl/sitl_test_mock_gps_node.py
+++ b/test/sitl/sitl_test_mock_gps_node.py
@@ -10,7 +10,8 @@ from mavsdk.log_files import LogFilesError, LogFilesResult
 
 SYS_ADDR = "udp://0.0.0.0:14550"
 MISSION_FILE = os.path.join(os.path.dirname(__file__), "../assets/ksql_airport.plan")
-MAVLINK_CONNECTION_TIMEOUT_SEC = 30
+# PX4 Gazebo container startup is too slow, fix once stable PX4 v1.14 is out
+MAVLINK_CONNECTION_TIMEOUT_SEC = 180
 PRE_FLIGHT_HEALTH_CHECK_TIMEOUT_SEC = 30
 LOG_OUTPUT_PATH = os.path.join(os.path.dirname(__file__), "output")
 

--- a/test/sitl/sitl_test_mock_gps_node.py
+++ b/test/sitl/sitl_test_mock_gps_node.py
@@ -8,12 +8,6 @@ from functools import partial
 from mavsdk import System
 from mavsdk.log_files import LogFilesError, LogFilesResult
 
-DOCKER_CONTAINERS = [
-    "gisnav-mapserver-1",
-    "gisnav-px4-1",
-    "gisnav-micro-ros-agent-1",
-    "gisnav-gisnav-1",
-]
 SYS_ADDR = "udp://0.0.0.0:14550"
 MISSION_FILE = os.path.join(os.path.dirname(__file__), "../assets/ksql_airport.plan")
 MAVLINK_CONNECTION_TIMEOUT_SEC = 30
@@ -137,7 +131,8 @@ def setup():
     This most likely means starting supporting services with docker
     """
     print("Starting SITL environment...")
-    os.system("docker start " + " ".join(DOCKER_CONTAINERS))
+    os.system("make -C docker up-offboard-sitl-test-px4")
+    os.system("docker compose -f docker/docker-compose.yaml up -d gisnav")
 
 
 def cleanup():
@@ -147,8 +142,7 @@ def cleanup():
     so that they won't be left running if the tests fail because of an error)
     """
     print("Shutting down SITL environment...")
-    for container in DOCKER_CONTAINERS:
-        os.system(f"docker kill {container}")
+    os.system("make -C docker down")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Update SITL test for recent docker reorg
- Fix recently introduced WMS server connection bug
- Update path in CI workflow to make pre-commit run

Note: The Gazebo simulation starts very slowly so the Mavlink connection timeout is increased in `sitl_test_mock_gps_node.py`. Will look into optimizing the `px4` container startup once PX4 v1.14 is out.