### PR TITLE
Use decorators for ROS boilerplate

### DIFF
--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -30,8 +30,8 @@ def enforce_types(
     logger: Optional[Callable[[str], Any]] = None, custom_msg: Optional[str] = None
 ) -> Callable[[Callable[P, T]], Callable[P, Optional[T]]]:
     """
-    Wrapper function to check if provided arguments match the method's type
-    hints.
+    Function decorator to narrow provided argument types to match the decorated
+    function's type hints.
 
     If any of the arguments do not match their corresponding type hints, this
     decorator optionally logs the mismatches and then returns None without
@@ -41,7 +41,9 @@ def enforce_types(
     .. warning::
         * If the decorated method can also return None after execution you will
           not be able to tell from the return value whether the method executed
-          or the type narrowing failed.
+          or the type narrowing failed. # TODO: the decorator should log a
+          warning or perhaps even raise an error if the decorated function
+          includes a None return type.
 
     .. note::
         This decorator streamlines computed properties by automating the check
@@ -54,15 +56,16 @@ def enforce_types(
         input argument
     :param custom_msg: Optional custom messag to prefix to the logging
     :return: The return value of the original method or None if any argument
-        does not match the type hints.
+        does not match the type hints. Be aware that the original method could
+        also return None after execution.
     """
 
     def decorator(method: Callable[P, T]) -> Callable[P, Optional[T]]:
         @wraps(method)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[T]:
             """
-            This wrapper function validates the provided arguments against the type
-            hints of the wrapped method.
+            This wrapper function validates the provided arguments against the
+            type hints of the wrapped method.
 
             :param args: Positional arguments passed to the original method.
             :param kwargs: Keyword arguments passed to the original method.

--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -31,7 +31,7 @@ def enforce_types(
 ) -> Callable[[Callable[P, T]], Callable[P, Optional[T]]]:
     """
     Function decorator to narrow provided argument types to match the decorated
-    function's type hints.
+    function's type hints *in a ``mypy`` compatible way*.
 
     If any of the arguments do not match their corresponding type hints, this
     decorator optionally logs the mismatches and then returns None without

--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -208,6 +208,11 @@ def validate(
 
 
 class ROS:
+    """
+    Decorators to get boilerplate code out of the Nodes to make it easier to
+    see what comes in, what goes out, and what gets transformed.
+    """
+
     # TODO: callback type, use typevar
     @staticmethod
     def subscribe(topic_name: str, qos):
@@ -239,7 +244,7 @@ class ROS:
                 def terrain_altitude(self) -> Optional[Altitude]:
                     pass
 
-                @ROS.subscribe.callback(terrain_altitude)
+                @ROS.callback(terrain_altitude)
                 def terrain_altitude_cb(self, msg: Altitude):
                     self.get_logger().debug("This is a callback")
 
@@ -276,6 +281,8 @@ class ROS:
                         # TODO: make this more efficient
                         for attr_name in dir(self):
                             attr = getattr(self, attr_name)
+                            # TODO: this hard-coded attr name is also used by callback
+                            #  -> brittle
                             if hasattr(attr, f"__ros_callback_for_{id(wrapper)}"):
                                 callback_method = attr
                                 break
@@ -315,6 +322,7 @@ class ROS:
         """
 
         def decorator_callback(func):
+            # TODO: this hard-coded attr name is also used by subscribe -> brittle
             setattr(func, f"__ros_callback_for_{id(property_instance)}", True)
             return func
 

--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -86,6 +86,8 @@ def enforce_types(
                         check = any(type_matches) if type_matches is not None else False
 
                     if not check:
+                        # TODO: debug log level if value is None (expected to
+                        # happen), set warn flag if value is something else?
                         mismatches.append((name, expected_type, type(value)))
 
             if mismatches:

--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -193,185 +193,246 @@ def validate(
     return inner_decorator
 
 
-def ros_subscribe(topic_name: str, qos):
-    """
-    A decorator to create a managed attribute (property) that subscribes to a
-    ROS topic with the same type as the property. The property should be an
-    optional type, e.g. Optional[Altitude], where a None value indicates the
-    message has not been received yet.
+class ROS:
+    #: Name of attribute in which optional subscribe callback is stored
+    _CALLBACK_FUNC_NAME = "_callback"
 
-    # TODO: enforce or check optional type
+    # TODO: callback type, use typevar
+    @staticmethod
+    def subscribe(topic_name: str, qos):
+        """
+        A decorator to create a managed attribute (property) that subscribes to a
+        ROS topic with the same type as the property. The property should be an
+        optional type, e.g. Optional[Altitude], where a None value indicates the
+        message has not been received yet.
 
-    Example usage:
+        The decorator also supports defining an optional callback method within
+        the decorated property. This method should be named ``callback`` and can be
+        decorated using the ``@ROS.subscribe.callback`` syntax.
+        # TODO: enforce or check optional type
 
-    .. code-block:: python
+        Example usage:
 
-        from mavros_msgs.msg import Altitude
-        from typing import Optional
+        .. code-block:: python
 
-        from . import messaging
+            from mavros_msgs.msg import Altitude
+            from typing import Optional
 
-        class AutopilotNode:
+            from . import messaging
 
-            ...
+            class AutopilotNode:
+                ...
 
-            @property
-            @ros_subscribe(messaging.ROS_TOPIC_TERRAIN_ALTITUDE, 10)
-            def terrain_altitude(self) -> Optional[Altitude]:
-                pass
+                @property
+                @ROS.subscribe(messaging.ROS_TOPIC_TERRAIN_ALTITUDE, 10)
+                def terrain_altitude(self) -> Optional[Altitude]:
+                    pass
 
+                @ROS.subscribe.callback(terrain_altitude)
+                def terrain_altitude_cb(self, msg: Altitude):
+                    self.get_logger().debug("This is a callback")
 
-    :param topic_name: The name of the ROS topic to subscribe to.
-    :param qos: The Quality of Service settings for the topic subscription.
-    :return: A property that holds the latest message from the specified ROS
-        topic, or None if no messages have been received yet.
-    """
+        In this example, the ``terrain_altitude`` property subscribes to the
+        ``messaging.ROS_TOPIC_TERRAIN_ALTITUDE`` ROS topic, and the
+        ``terrain_altitude`` method decorated with
+        ``@ROS.subscribe.callback(terrain_altitude)`` will be executed every
+        time a new message is received and stored.
 
-    def decorator_property(func):
-        @wraps(func)
-        def wrapper(self):
+        :param topic_name: The name of the ROS topic to subscribe to.
+        :param qos: The Quality of Service settings for the topic subscription.
+        :return: A property that holds the latest message from the specified ROS
+            topic, or None if no messages have been received yet.
+        """
+
+        def decorator_property(func):
+            @wraps(func)
+            def wrapper(self):
+                """
+                Wrapper function for the property.
+
+                :param self: The instance of the class the property belongs to.
+                :return: The value of the property.
+                """
+                cached_property_name = f"_{func.__name__}"
+                cached_subscription_name = f"{cached_property_name}_subscription"
+
+                if not hasattr(wrapper, cached_subscription_name):
+
+                    def _on_message(message):
+                        setattr(self, cached_property_name, message)
+                        if hasattr(func, "_callback"):
+                            callback_method = getattr(func, "_callback")
+                            callback_method(self, message)
+
+                    optional_type = get_type_hints(func)["return"]
+                    topic_type = get_args(optional_type)[
+                        0
+                    ]  # brittle? handle this better
+                    subscription = self.create_subscription(
+                        topic_type,
+                        topic_name,
+                        _on_message,
+                        qos,
+                    )
+                    setattr(wrapper, cached_subscription_name, subscription)
+
+                # return getattr(self, cached_property_name, func(self))
+                return getattr(self, cached_property_name, None)
+
+            return wrapper
+
+        return decorator_property
+
+    @staticmethod
+    def callback(outer_property):
+        """
+        A decorator factory that makes the decorated function an inner function
+        of the provided outer property.
+
+        :param outer_property: The outer property that the decorated function will
+            be made an inner function of.
+        :return decorator: The actual decorator that will be applied to the
+            target function.
+        """
+
+        def decorator(func):
             """
-            Wrapper function for the property.
+            The actual decorator that takes the target function and attaches
+            it as an inner function to the outer property's getter method.
 
-            :param self: The instance of the class the property belongs to.
-            :return: The value of the property.
+            :param func: The target function to be made an inner function
+                of the outer property's getter method.
+            :return wrapper: The wrapped function with the same functionality
+                as the original function.
             """
-            cached_property_name = f"_{func.__name__}"
-            cached_subscription_name = f"{cached_property_name}_subscription"
 
-            if not hasattr(wrapper, cached_subscription_name):
-                optional_type = get_type_hints(func)["return"]
-                topic_type = get_args(optional_type)[0]  # brittle? handle this better
-                subscription = self.create_subscription(
-                    topic_type,
-                    topic_name,
-                    lambda message: setattr(self, cached_property_name, message),
-                    qos,
+            def wrapper(*args, **kwargs):
+                """A simple pass-through for the decorated function."""
+                return func(*args, **kwargs)
+
+            if not isinstance(outer_property, property):
+                raise TypeError("The outer object must be a property")
+
+            setattr(outer_property.fget, "_callback", wrapper)
+            return wrapper
+
+        return decorator
+
+    # TODO: use default topic name, e.g. "~/message_type"?
+    # TODO: add type hints, see subscribe decorator, use TypeVar("M") below?
+    @staticmethod
+    def publish(topic_name: str, qos):
+        """
+        A decorator to create a managed attribute (property) that publishes its
+        value over a ROS topic whenever it's called.
+
+        :param topic_name: The name of the ROS topic to publish to.
+        :param qos: The Quality of Service settings for the topic publishing.
+        :return: A property that publishes its value to the specified ROS topic
+            whenever the property is called
+        """
+
+        def decorator_property(func):
+            @wraps(func)
+            def wrapper(self, *args, **kwargs):
+                """
+                Wrapper function for the property.
+
+                :param self: The instance of the class the property belongs to.
+                :return: The value of the property.
+                """
+                value = func(self, *args, **kwargs)
+                cached_publisher_name = f"_{func.__name__}_publisher"
+
+                if not hasattr(wrapper, cached_publisher_name):
+                    optional_type = get_type_hints(func)["return"]
+                    topic_type = get_args(optional_type)[
+                        0
+                    ]  # brittle? handle this better
+                    publisher = self.__vehicle_altitude_pub = self.create_publisher(
+                        topic_type,
+                        topic_name,
+                        qos,
+                    )
+                    setattr(wrapper, cached_publisher_name, publisher)
+
+                if value is not None:
+                    getattr(wrapper, cached_publisher_name).publish(value)
+
+                return value
+
+            # return property(wrapper)
+            return wrapper
+
+        return decorator_property
+
+    @staticmethod
+    def max_delay_ms(max_time_diff_ms: int):
+        """
+        A decorator that checks the property's ROS header timestamp and compares
+        it to the current clock. If the time difference is larger than what is
+        provided to the decorator (in milliseconds), the decorated function logs a
+        warning and returns None instead.
+
+        :param max_time_diff_ms: Maximum allowed time difference in milliseconds.
+        :return: The wrapped function or method with added timestamp checking. The
+            decorated function returns None if the timestamp is too old.
+        """
+
+        class HasHeader:
+            """
+            Dummy class representing any ROS message class that should have the
+            header attribute
+            """
+
+            header: Header
+
+        M = TypeVar("M", bound=HasHeader)
+
+        def _timestamp_diff_in_milliseconds(ts1, ts2):
+            # Convert the timestamps to milliseconds
+            ts1_ms = ts1.sec * 1000 + ts1.nanosec / 1e6
+            ts2_ms = ts2.sec * 1000 + ts2.nanosec / 1e6
+
+            # Compute the difference between the two timestamps in milliseconds
+            diff_ms = ts2_ms - ts1_ms
+
+            return diff_ms
+
+        def decorator(func: Callable[[Node], M]) -> Callable[[Node], Optional[M]]:
+            @wraps(func)
+            def wrapper(self: Node) -> Optional[M]:
+                """
+                Wrapper function for the property.
+
+                :param self: The instance of the :class:`rclpy.Node` the property
+                    belongs to.
+                :return: The value of the property if the time difference is within
+                    the allowed limit or None otherwise.
+                """
+                message = func(self)
+                if message is None:
+                    return None
+
+                header_timestamp = message.header.stamp
+                current_timestamp = self.get_clock().now().to_msg()
+                time_diff = _timestamp_diff_in_milliseconds(
+                    header_timestamp, current_timestamp
                 )
-                setattr(wrapper, cached_subscription_name, subscription)
 
-            # return getattr(self, cached_property_name, func(self))
-            return getattr(self, cached_property_name, None)
+                if time_diff > max_time_diff_ms:
+                    self.get_logger().warn(
+                        f"Time difference ({time_diff} ms) exceeded allowed limit "
+                        f"({max_time_diff_ms} ms)."
+                    )
+                    return None
 
-        return wrapper
+                return message
 
-    return decorator_property
+            # return property(wrapper)
+            return wrapper
 
-
-# TODO: use default topic name, e.g. "~/message_type"?
-# TODO: add type hints, see subscribe decorator, use TypeVar("M") below?
-def ros_publish(topic_name: str, qos):
-    """
-    A decorator to create a managed attribute (property) that publishes its
-    value over a ROS topic whenever it's called.
-
-    :param topic_name: The name of the ROS topic to publish to.
-    :param qos: The Quality of Service settings for the topic publishing.
-    :return: A property that publishes its value to the specified ROS topic
-        whenever the property is called
-    """
-
-    def decorator_property(func):
-        @wraps(func)
-        def wrapper(self, *args, **kwargs):
-            """
-            Wrapper function for the property.
-
-            :param self: The instance of the class the property belongs to.
-            :return: The value of the property.
-            """
-            value = func(self, *args, **kwargs)
-            cached_publisher_name = f"_{func.__name__}_publisher"
-
-            if not hasattr(wrapper, cached_publisher_name):
-                optional_type = get_type_hints(func)["return"]
-                topic_type = get_args(optional_type)[0]  # brittle? handle this better
-                publisher = self.__vehicle_altitude_pub = self.create_publisher(
-                    topic_type,
-                    topic_name,
-                    qos,
-                )
-                setattr(wrapper, cached_publisher_name, publisher)
-
-            if value is not None:
-                getattr(wrapper, cached_publisher_name).publish(value)
-
-            return value
-
-        # return property(wrapper)
-        return wrapper
-
-    return decorator_property
-
-
-class HasHeader:
-    """
-    Dummy class representing any ROS message class that should have the
-    header attribute
-    """
-
-    header: Header
-
-
-M = TypeVar("M", bound=HasHeader)
-
-
-def ros_max_delay_ms(max_time_diff_ms: int):
-    """
-    A decorator that checks the property's ROS header timestamp and compares
-    it to the current clock. If the time difference is larger than what is
-    provided to the decorator (in milliseconds), the decorated function logs a
-    warning and returns None instead.
-
-    :param max_time_diff_ms: Maximum allowed time difference in milliseconds.
-    :return: The wrapped function or method with added timestamp checking. The
-        decorated function returns None if the timestamp is too old.
-    """
-
-    def _timestamp_diff_in_milliseconds(ts1, ts2):
-        # Convert the timestamps to milliseconds
-        ts1_ms = ts1.sec * 1000 + ts1.nanosec / 1e6
-        ts2_ms = ts2.sec * 1000 + ts2.nanosec / 1e6
-
-        # Compute the difference between the two timestamps in milliseconds
-        diff_ms = ts2_ms - ts1_ms
-
-        return diff_ms
-
-    def decorator(func: Callable[[Node], M]) -> Callable[[Node], Optional[M]]:
-        @wraps(func)
-        def wrapper(self: Node) -> Optional[M]:
-            """
-            Wrapper function for the property.
-
-            :param self: The instance of the :class:`rclpy.Node` the property
-                belongs to.
-            :return: The value of the property if the time difference is within
-                the allowed limit or None otherwise.
-            """
-            message = func(self)
-            if message is None:
-                return None
-
-            header_timestamp = message.header.stamp
-            current_timestamp = self.get_clock().now().to_msg()
-            time_diff = _timestamp_diff_in_milliseconds(
-                header_timestamp, current_timestamp
-            )
-
-            if time_diff > max_time_diff_ms:
-                self.get_logger().warn(
-                    f"Time difference ({time_diff} ms) exceeded allowed limit "
-                    f"({max_time_diff_ms} ms)."
-                )
-                return None
-
-            return message
-
-        # return property(wrapper)
-        return wrapper
-
-    return decorator
+        return decorator
 
 
 def assert_type(value: object, type_: Any) -> None:

--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -22,7 +22,7 @@ from typing_extensions import ParamSpec
 #: Original return type of the wrapped method
 T = TypeVar("T")
 
-#: Original param specification of the wrapped method
+#: Param specification of the wrapped method
 P = ParamSpec("P")
 
 

--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -49,7 +49,7 @@ def enforce_types(
 
     def decorator(method: F) -> F:
         @wraps(method)
-        def wrapper(*args: Any, **kwargs: Any) -> Union[Any, None]:
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             """
             This wrapper function validates the provided arguments against the type
             hints of the wrapped method.

--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -17,18 +17,22 @@ from typing import (
 )
 
 import numpy as np
-from typing_extensions import ParamSpec
+
+# from typing_extensions import ParamSpec
 
 #: Original return type of the wrapped method
 T = TypeVar("T")
 
 #: Param specification of the wrapped method
-P = ParamSpec("P")
+# P = ParamSpec("P")
+# TODO: using ellipsis (...) for Callable arguments instead of ParamSpec because
+# the decorated function is not expected to have the same ParamSpec. However, should
+# check that the *args are the same length and **kwargs have the same keys?
 
 
 def enforce_types(
     logger: Optional[Callable[[str], Any]] = None, custom_msg: Optional[str] = None
-) -> Callable[[Callable[P, T]], Callable[P, Optional[T]]]:
+) -> Callable[[Callable[..., T]], Callable[..., Optional[T]]]:
     """
     Function decorator to narrow provided argument types to match the decorated
     function's type hints *in a ``mypy`` compatible way*.
@@ -54,15 +58,15 @@ def enforce_types(
 
     :param logger: Optional logging callable that accepts a string message as
         input argument
-    :param custom_msg: Optional custom messag to prefix to the logging
+    :param custom_msg: Optional custom message to prefix to the logging
     :return: The return value of the original method or None if any argument
         does not match the type hints. Be aware that the original method could
         also return None after execution.
     """
 
-    def decorator(method: Callable[P, T]) -> Callable[P, Optional[T]]:
+    def decorator(method: Callable[..., T]) -> Callable[..., Optional[T]]:
         @wraps(method)
-        def wrapper(*args: P.args, **kwargs: P.kwargs) -> Optional[T]:
+        def wrapper(*args, **kwargs) -> Optional[T]:
             """
             This wrapper function validates the provided arguments against the
             type hints of the wrapped method.
@@ -117,7 +121,7 @@ def enforce_types(
 
             return method(*args, **kwargs)
 
-        return cast(Callable[P, Optional[T]], wrapper)
+        return cast(Callable[..., Optional[T]], wrapper)
 
     return decorator
 

--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -359,7 +359,7 @@ class ROS:
                     topic_type = get_args(optional_type)[
                         0
                     ]  # brittle? handle this better
-                    publisher = self.__vehicle_altitude_pub = self.create_publisher(
+                    publisher = self.create_publisher(
                         topic_type,
                         topic_name,
                         qos,

--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -206,9 +206,6 @@ def validate(
 
 
 class ROS:
-    #: Name of attribute in which optional subscribe callback is stored
-    _CALLBACK_FUNC_NAME = "_callback"
-
     # TODO: callback type, use typevar
     @staticmethod
     def subscribe(topic_name: str, qos):

--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -262,6 +262,7 @@ class ROS:
                         setattr(self, cached_property_name, message)
 
                         # Look for defined callback and execute it
+                        # TODO: make this more efficient
                         for attr_name in dir(self):
                             attr = getattr(self, attr_name)
                             if hasattr(attr, f"__ros_callback_for_{id(wrapper)}"):

--- a/gisnav/gisnav/assertions.py
+++ b/gisnav/gisnav/assertions.py
@@ -40,7 +40,8 @@ def enforce_types(
         computed, resulting in cleaner property implementations with less
         boilerplate code.
 
-    :param logger: Optional logging callable that accepts a string message
+    :param logger: Optional logging callable that accepts a string message as
+        input argument
     :param custom_msg: Optional custom messag to prefix to the logging
     :return: The return value of the original method or None if any argument
         does not match the type hints.

--- a/gisnav/gisnav/geo.py
+++ b/gisnav/gisnav/geo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import math
 import warnings
 from abc import ABC
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Tuple, TypeVar
 
 import numpy as np
 from geopandas import GeoSeries
@@ -36,6 +36,8 @@ class _GeoObject(ABC):
     DEFAULT_CRS = "epsg:4326"
     """Use WGS 84 latitude and longitude by default"""
 
+    G = TypeVar("G", bound="_GeoObject")
+
     @property
     def _geoseries(self) -> GeoSeries:
         return self.__geoseries
@@ -59,10 +61,10 @@ class _GeoObject(ABC):
         """Returns the wrapped shape as a numpy array"""
         return self._geoseries[0].coords[0]
 
-    def to_crs(self, crs: str) -> _GeoObject:  # TODO: return None? Misleading this way
+    def to_crs(self: G, crs: str) -> G:  # TODO: return None? Misleading this way
         """Converts to provided CRS
 
-        :return: The same GeoPt instance transformed to new CRS
+        :return: The same _GeoObject inheriting instance transformed to new CRS
         """
         if self._geoseries.crs != crs:
             self._geoseries = self._geoseries.to_crs(crs)

--- a/gisnav/gisnav/nodes/autopilot_node.py
+++ b/gisnav/gisnav/nodes/autopilot_node.py
@@ -246,7 +246,7 @@ class AutopilotNode(RVizPublisherNode):
             navsatfix: NavSatFix,
             egm96_height: Float32,
             terrain_altitude: Altitude,
-            vehicle_altitude_local: Optional[Altitude],
+            vehicle_altitude_local: Optional[float],
         ):
             vehicle_altitude_amsl = navsatfix.altitude - egm96_height.data
             vehicle_altitude_terrain = vehicle_altitude_amsl - terrain_altitude.amsl

--- a/gisnav/gisnav/nodes/autopilot_node.py
+++ b/gisnav/gisnav/nodes/autopilot_node.py
@@ -11,12 +11,7 @@ from scipy.spatial.transform import Rotation
 from sensor_msgs.msg import NavSatFix
 from std_msgs.msg import Float32
 
-from gisnav.assertions import (
-    enforce_types,
-    ros_max_delay_ms,
-    ros_publish,
-    ros_subscribe,
-)
+from gisnav.assertions import ROS, enforce_types
 
 from . import messaging
 from .base.rviz_publisher_node import RVizPublisherNode
@@ -35,76 +30,137 @@ class AutopilotNode(RVizPublisherNode):
         """
         super().__init__(name)
 
-        # Publishers
-        # Use name mangling to protect these from being overwritten by extending
-        # classes
-        self.__vehicle_geopose_pub = self.create_publisher(
-            GeoPoseStamped,
-            messaging.ROS_TOPIC_VEHICLE_GEOPOSE,
-            QoSPresetProfiles.SENSOR_DATA.value,
-        )
-        self.__gimbal_quaternion_pub = self.create_publisher(
-            Quaternion,
-            messaging.ROS_TOPIC_GIMBAL_QUATERNION,
-            QoSPresetProfiles.SENSOR_DATA.value,
-        )
-        self.__home_geopoint_pub = self.create_publisher(
-            GeoPointStamped,
-            messaging.ROS_TOPIC_HOME_GEOPOINT,
-            QoSPresetProfiles.SENSOR_DATA.value,
-        )
-
-        # Subscribers
-        # terrain_altitude and egm96_height properties intended to be used by
-        # extending classes -> no name mangling
-        self.egm96_height: Optional[Float32] = None
-        self.__egm96_height_sub = self.create_subscription(
-            Float32,
-            messaging.ROS_TOPIC_EGM96_HEIGHT,
-            self.__egm96_height_callback,
-            QoSPresetProfiles.SENSOR_DATA.value,
-        )
-
-        self._vehicle_nav_sat_fix: Optional[NavSatFix] = None
-        self._vehicle_nav_sat_fix_sub = self.create_subscription(
-            NavSatFix,
-            "/mavros/global_position/global",
-            self._vehicle_nav_sat_fix_callback,
-            QoSPresetProfiles.SENSOR_DATA.value,
-        )
-        self._vehicle_pose_stamped: Optional[PoseStamped] = None
-        self._vehicle_pose_stamped_sub = self.create_subscription(
-            PoseStamped,
-            "/mavros/local_position/pose",
-            self._vehicle_pose_stamped_callback,
-            QoSPresetProfiles.SENSOR_DATA.value,
-        )
-        self._home_position: Optional[HomePosition] = None
-        self._home_position_sub = self.create_subscription(
-            HomePosition,
-            "/mavros/home_position/home",
-            self._home_position_callback,
-            QoSPresetProfiles.SENSOR_DATA.value,
-        )
-        self._gimbal_device_attitude_status: Optional[GimbalDeviceAttitudeStatus] = None
-        self._gimbal_device_attitude_status_sub = self.create_subscription(
-            GimbalDeviceAttitudeStatus,
-            "/mavros/gimbal_control/device/attitude_status",
-            self._gimbal_device_attitude_status_callback,
-            QoSPresetProfiles.SENSOR_DATA.value,
-        )
+        # Calling these decorated properties the first time will setup
+        # subscriptions to the appropriate ROS topics
+        self.terrain_altitude
+        self.egm96_height
+        self.nav_sat_fix
+        self.pose_stamped
+        self.home_position
 
     @property
-    @ros_max_delay_ms(500)
-    @ros_subscribe(
+    @ROS.max_delay_ms(500)
+    @ROS.subscribe(
         messaging.ROS_TOPIC_TERRAIN_ALTITUDE, QoSPresetProfiles.SENSOR_DATA.value
     )
     def terrain_altitude(self) -> Optional[Altitude]:
         """Altitude of terrain directly under vehicle, or None if unknown or too old"""
 
     @property
-    @ros_max_delay_ms(500)  # Note: gets published before this check
-    @ros_publish(
+    @ROS.max_delay_ms(500)
+    @ROS.subscribe(
+        messaging.ROS_TOPIC_EGM96_HEIGHT, QoSPresetProfiles.SENSOR_DATA.value
+    )
+    def egm96_height(self) -> Optional[Altitude]:
+        """
+        Height in meters of EGM96 geoid at vehicle location, or None if unknown
+        or too old
+        """
+
+    @property
+    @ROS.max_delay_ms(500)
+    @ROS.subscribe(
+        "/mavros/global_position/global", QoSPresetProfiles.SENSOR_DATA.value
+    )
+    def nav_sat_fix(self) -> Optional[NavSatFix]:
+        """Vehicle GPS fix, or None if unknown or too old"""
+
+    @ROS.callback(nav_sat_fix)
+    def nav_sat_fix_cb(self, msg: NavSatFix) -> None:
+        """Callback for :class:`mavros_msgs.msg.NavSatFix` message
+
+        Publishes vehicle :class:`.geographic_msgs.msg.GeoPoseStamped` and
+        :class:`mavros_msgs.msg.Altitude` because the contents of those messages
+        are affected by this update.
+
+        :param msg: :class:`mavros_msgs.msg.NavSatFix` message from MAVROS
+        """
+
+        def _navsatfix_to_geoposestamped(msg: NavSatFix) -> GeoPoseStamped:
+            # Publish to rviz2 for debugging
+            geopose_stamped = GeoPoseStamped()
+            geopose_stamped.header.stamp = msg.header.stamp
+            geopose_stamped.header.frame_id = "map"
+
+            geopose_stamped.pose.position.longitude = msg.longitude
+            geopose_stamped.pose.position.latitude = msg.latitude
+            geopose_stamped.pose.position.altitude = msg.altitude
+
+            # No orientation information in NavSatFix
+            geopose_stamped.pose.orientation.w = 1.0
+
+            return geopose_stamped
+
+        self.geopose_stamped
+        altitude = self.altitude
+
+        # TODO: temporarily assuming static camera so publishing gimbal quat here
+        self.gimbal_quaternion
+
+        if altitude is not None and altitude.terrain is not np.nan:
+            # publish to RViz for debugging and visualization
+            geopose_stamped = _navsatfix_to_geoposestamped(msg)
+            self.publish_rviz(geopose_stamped, altitude.terrain)
+
+    @property
+    @ROS.max_delay_ms(500)
+    @ROS.subscribe("/mavros/local_position/pose", QoSPresetProfiles.SENSOR_DATA.value)
+    def pose_stamped(self) -> Optional[PoseStamped]:
+        """Vehicle GPS fix, or None if unknown or too old"""
+
+    @ROS.callback(pose_stamped)
+    def pose_stamped_cb(self, msg: PoseStamped) -> None:
+        """Callback for :class:`mavros_msgs.msg.PoseStamped` message
+
+        Publishes :class:`.geographic_msgs.msg.GeoPoseStamped` because the
+        content of that message is affected by this update.
+
+        :param msg: :class:`mavros_msgs.msg.PoseStamped` message from MAVROS
+        """
+        self.geopose_stamped
+        # self.publish_vehicle_altitude()  # Needed? This is mainly about vehicle pose
+
+    @property
+    @ROS.max_delay_ms(500)
+    @ROS.subscribe("/mavros/home_position/home", QoSPresetProfiles.SENSOR_DATA.value)
+    def home_position(self) -> Optional[HomePosition]:
+        """Home position, or None if unknown or too old"""
+
+    @ROS.callback(home_position)
+    def home_position_cb(self, msg: HomePosition) -> None:
+        """Callback for :class:`mavros_msgs.msg.HomePosition` message
+
+        Publishes home :class:`.geographic_msgs.msg.GeoPointStamped` because
+        the content of that message is affected by this update.
+
+        :param msg: :class:`mavros_msgs.msg.HomePosition` message from MAVROS
+        """
+        self.home_geopoint
+
+    @property
+    @ROS.max_delay_ms(500)
+    @ROS.subscribe(
+        "/mavros/gimbal_control/device/attitude_status",
+        QoSPresetProfiles.SENSOR_DATA.value,
+    )
+    def gimbal_device_attitude_status(self) -> Optional[GimbalDeviceAttitudeStatus]:
+        """Gimbal attitude, or None if unknown or too old"""
+
+    @ROS.callback(gimbal_device_attitude_status)
+    def gimbal_device_attitude_status_cb(self, msg: GimbalDeviceAttitudeStatus) -> None:
+        """Callback for :class:`mavros_msgs.msg.GimbalDeviceAttitudeStatus` message
+
+        Publishes gimbal :class:`.geometry_msgs.msg.Quaternion` because the
+        content of that message is affected by this update.
+
+        :param msg: :class:`mavros_msgs.msg.GimbalDeviceAttitudeStatus` message
+            from MAVROS
+        """
+        self.gimbal_quaternion
+
+    @property
+    @ROS.max_delay_ms(500)  # Note: gets published before this check
+    @ROS.publish(
         messaging.ROS_TOPIC_VEHICLE_ALTITUDE, QoSPresetProfiles.SENSOR_DATA.value
     )
     def vehicle_altitude(self) -> Optional[Altitude]:
@@ -112,16 +168,14 @@ class AutopilotNode(RVizPublisherNode):
 
         @enforce_types(self.get_logger().warn, "Cannot determine vehicle altitude")
         def _vehicle_altitude(
-            navsatfix: NavSatFix,
+            nav_sat_fix: NavSatFix,
             egm96_height: Float32,
             terrain_altitude: Altitude,
-            vehicle_altitude_local: Optional[float],
+            altitude_local: Optional[float],
         ):
-            vehicle_altitude_amsl = navsatfix.altitude - egm96_height.data
+            vehicle_altitude_amsl = nav_sat_fix.altitude - egm96_height.data
             vehicle_altitude_terrain = vehicle_altitude_amsl - terrain_altitude.amsl
-            local = (
-                vehicle_altitude_local if vehicle_altitude_local is not None else np.nan
-            )
+            local = altitude_local if altitude_local is not None else np.nan
             altitude = Altitude(
                 header=messaging.create_header("base_link"),
                 amsl=vehicle_altitude_amsl,
@@ -133,111 +187,35 @@ class AutopilotNode(RVizPublisherNode):
             return altitude
 
         return _vehicle_altitude(
-            self._vehicle_nav_sat_fix,
+            self.nav_sat_fix,
             self.egm96_height,
             self.terrain_altitude,
-            self._vehicle_altitude_local,
+            self._altitude_local,
         )
 
-    @staticmethod
-    def _navsatfix_to_geoposestamped(msg: NavSatFix) -> GeoPoseStamped:
-        # Publish to rviz2 for debugging
-        geopose_stamped = GeoPoseStamped()
-        geopose_stamped.header.stamp = msg.header.stamp
-        geopose_stamped.header.frame_id = "map"
-
-        geopose_stamped.pose.position.longitude = msg.longitude
-        geopose_stamped.pose.position.latitude = msg.latitude
-        geopose_stamped.pose.position.altitude = msg.altitude
-
-        # No orientation information in NavSatFix
-        geopose_stamped.pose.orientation.w = 1.0
-
-        return geopose_stamped
-
-    # region ROS subscriber callbacks
-    def _vehicle_nav_sat_fix_callback(self, msg: NavSatFix) -> None:
-        """Handles latest :class:`mavros_msgs.msg.NavSatFix` message
-
-        Calls :meth:`.publish_vehicle_geopose` and :meth:`.publish_vehicle_altitude`
-        because the contents of those messages are affected by an updated
-        :class:`mavros_msgs.msg.NavSatFix` message.
-
-        :param msg: :class:`mavros_msgs.msg.NavSatFix` message from MAVROS
-        """
-        self._vehicle_nav_sat_fix = msg
-        self.publish_vehicle_geopose()
-        vehicle_altitude = (
-            self.vehicle_altitude
-        )  # publishes vehicle altitude if available
-        # TODO: temporarily assuming static camera so publishing gimbal quat here
-        self.publish_gimbal_quaternion()
-
-        if vehicle_altitude is not None and vehicle_altitude.terrain is not np.nan:
-            # publish to RViz for debugging and visualization
-            geopose_stamped = self._navsatfix_to_geoposestamped(msg)
-            self.publish_rviz(geopose_stamped, vehicle_altitude.terrain)
-
-    def _vehicle_pose_stamped_callback(self, msg: PoseStamped) -> None:
-        """Handles latest :class:`mavros_msgs.msg.PoseStamped` message
-
-        Calls :meth:`.publish_vehicle_geopose` because the content of that
-        message is affected by an updated :class:`mavros_msgs.msg.PoseStamped` message.
-
-        :param msg: :class:`mavros_msgs.msg.PoseStamped` message from MAVROS
-        """
-        self._vehicle_pose_stamped = msg
-        self.publish_vehicle_geopose()
-        # self.publish_vehicle_altitude()  # Needed? This is mainly about vehicle pose
-
-    def _home_position_callback(self, msg: HomePosition) -> None:
-        """Handles latest :class:`mavros_msgs.msg.HomePosition` message
-
-        Calls :meth:`.publish_home_geopoint` because the content of that message is
-        affected by an updated :class:`mavros_msgs.msg.HomePosition` message.
-
-        :param msg: :class:`mavros_msgs.msg.HomePosition` message from MAVROS
-        """
-        self._home_position = msg
-        self.publish_home_geopoint()
-
-    def _gimbal_device_attitude_status_callback(
-        self, msg: GimbalDeviceAttitudeStatus
-    ) -> None:
-        """Handles latest :class:`mavros_msgs.msg.GimbalDeviceAttitudeStatus` message
-
-        Calls :meth:`.publish_gimbal_quaternion` because the content of that
-        message is affected by an updated :class:`mavros_msgs.msg.MountControl` message.
-
-        :param msg: :class:`mavros_msgs.msg.MountControl` message from MAVROS
-        """
-        self._gimbal_device_attitude_status = msg
-        self.publish_gimbal_quaternion()
-
-    # endregion ROS subscriber callbacks
-
-    # region computed attributes
     @property
-    def vehicle_geopose(self) -> Optional[GeoPoseStamped]:
+    @ROS.max_delay_ms(500)
+    @ROS.publish(
+        messaging.ROS_TOPIC_VEHICLE_GEOPOSE, QoSPresetProfiles.SENSOR_DATA.value
+    )
+    def geopose_stamped(self) -> Optional[GeoPoseStamped]:
         """Vehicle pose as :class:`geographic_msgs.msg.GeoPoseStamped` message
         or None if not available"""
 
         @enforce_types(self.get_logger().warn, "Cannot determine vehicle GeoPose")
-        def _vehicle_geopose(
-            vehicle_nav_sat_fix: NavSatFix, vehicle_pose_stamped: PoseStamped
-        ):
+        def _geopose_stamped(nav_sat_fix: NavSatFix, pose_stamped: PoseStamped):
             # Position
             latitude, longitude = (
-                vehicle_nav_sat_fix.latitude,
-                vehicle_nav_sat_fix.longitude,
+                nav_sat_fix.latitude,
+                nav_sat_fix.longitude,
             )
-            altitude = vehicle_nav_sat_fix.altitude
+            altitude = nav_sat_fix.altitude
 
             # Convert ENU->NED + re-center yaw
             enu_to_ned = Rotation.from_euler("XYZ", np.array([np.pi, 0, np.pi / 2]))
             attitude_ned = (
                 Rotation.from_quat(
-                    messaging.as_np_quaternion(vehicle_pose_stamped.pose.orientation)
+                    messaging.as_np_quaternion(pose_stamped.pose.orientation)
                 )
                 * enu_to_ned.inv()
             )
@@ -257,80 +235,13 @@ class AutopilotNode(RVizPublisherNode):
                 ),
             )
 
-        return _vehicle_geopose(self._vehicle_nav_sat_fix, self._vehicle_pose_stamped)
+        return _geopose_stamped(self.nav_sat_fix, self.pose_stamped)
 
     @property
-    def _vehicle_altitude_local(self) -> Optional[float]:
-        """Returns z coordinate from :class:`sensor_msgs.msg.PoseStamped` message
-        or None if not available"""
-
-        @enforce_types(
-            self.get_logger().warn, "Cannot determine vehicle local altitude"
-        )
-        def _vehicle_altitude_local(vehicle_pose_stamped: PoseStamped):
-            return vehicle_pose_stamped.pose.position.z
-
-        return _vehicle_altitude_local(self._vehicle_pose_stamped)
-
-    @staticmethod
-    def _euler_from_quaternion(q):
-        # Convert quaternion to euler angles
-        t0 = 2.0 * (q.w * q.x + q.y * q.z)
-        t1 = 1.0 - 2.0 * (q.x * q.x + q.y * q.y)
-        roll = math.atan2(t0, t1)
-
-        t2 = 2.0 * (q.w * q.y - q.z * q.x)
-        t2 = 1.0 if t2 > 1.0 else t2
-        t2 = -1.0 if t2 < -1.0 else t2
-        pitch = math.asin(t2)
-
-        t3 = 2.0 * (q.w * q.z + q.x * q.y)
-        t4 = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
-        yaw = math.atan2(t3, t4)
-
-        return roll, pitch, yaw
-
-    @staticmethod
-    def yaw_from_quaternion(q):
-        t3 = 2.0 * (q.w * q.z + q.x * q.y)
-        t4 = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
-        yaw_rad = math.atan2(t3, t4)
-
-        # Convert to degrees and normalize to [0, 360)
-        yaw_deg = math.degrees(yaw_rad) % 360
-
-        return yaw_deg
-
-    @staticmethod
-    def quaternion_multiply(q1, q2):
-        w1, x1, y1, z1 = q1.w, q1.x, q1.y, q1.z
-        w2, x2, y2, z2 = q2.w, q2.x, q2.y, q2.z
-
-        w = w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2
-        x = w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2
-        y = w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2
-        z = w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2
-
-        return Quaternion(w=w, x=x, y=y, z=z)
-
-    @classmethod
-    def apply_vehicle_yaw(cls, vehicle_q, gimbal_q):
-        # Extract yaw from vehicle quaternion
-        t3 = 2.0 * (vehicle_q.w * vehicle_q.z + vehicle_q.x * vehicle_q.y)
-        t4 = 1.0 - 2.0 * (vehicle_q.y * vehicle_q.y + vehicle_q.z * vehicle_q.z)
-        yaw_rad = math.atan2(t3, t4)
-
-        # Create a new quaternion with only yaw rotation
-        yaw_q = Quaternion(
-            w=math.cos(yaw_rad / 2), x=0.0, y=0.0, z=math.sin(yaw_rad / 2)
-        )
-
-        # Apply the vehicle yaw rotation to the gimbal quaternion
-        gimbal_yaw_q = cls.quaternion_multiply(yaw_q, gimbal_q)
-
-        return gimbal_yaw_q
-
-    @property
+    @ROS.max_delay_ms(500)
+    @ROS.publish(
+        messaging.ROS_TOPIC_GIMBAL_QUATERNION, QoSPresetProfiles.SENSOR_DATA.value
+    )
     def gimbal_quaternion(self) -> Optional[Quaternion]:
         """Gimbal orientation as :class:`geometry_msgs.msg.Quaternion` message
         or None if not available
@@ -341,10 +252,54 @@ class AutopilotNode(RVizPublisherNode):
             is not available.
         """
 
+        def _euler_from_quaternion(q):
+            # Convert quaternion to euler angles
+            t0 = 2.0 * (q.w * q.x + q.y * q.z)
+            t1 = 1.0 - 2.0 * (q.x * q.x + q.y * q.y)
+            roll = math.atan2(t0, t1)
+
+            t2 = 2.0 * (q.w * q.y - q.z * q.x)
+            t2 = 1.0 if t2 > 1.0 else t2
+            t2 = -1.0 if t2 < -1.0 else t2
+            pitch = math.asin(t2)
+
+            t3 = 2.0 * (q.w * q.z + q.x * q.y)
+            t4 = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
+            yaw = math.atan2(t3, t4)
+
+            return roll, pitch, yaw
+
+        def _quaternion_multiply(q1, q2):
+            w1, x1, y1, z1 = q1.w, q1.x, q1.y, q1.z
+            w2, x2, y2, z2 = q2.w, q2.x, q2.y, q2.z
+
+            w = w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2
+            x = w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2
+            y = w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2
+            z = w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2
+
+            return Quaternion(w=w, x=x, y=y, z=z)
+
+        def _apply_vehicle_yaw(vehicle_q, gimbal_q):
+            # Extract yaw from vehicle quaternion
+            t3 = 2.0 * (vehicle_q.w * vehicle_q.z + vehicle_q.x * vehicle_q.y)
+            t4 = 1.0 - 2.0 * (vehicle_q.y * vehicle_q.y + vehicle_q.z * vehicle_q.z)
+            yaw_rad = math.atan2(t3, t4)
+
+            # Create a new quaternion with only yaw rotation
+            yaw_q = Quaternion(
+                w=math.cos(yaw_rad / 2), x=0.0, y=0.0, z=math.sin(yaw_rad / 2)
+            )
+
+            # Apply the vehicle yaw rotation to the gimbal quaternion
+            gimbal_yaw_q = _quaternion_multiply(yaw_q, gimbal_q)
+
+            return gimbal_yaw_q
+
         # TODO check frame (e.g. base_link_frd/vehicle body in PX4 SITL simulation)
         @enforce_types(self.get_logger().warn, "Cannot determine gimbal Quaternion")
         def _gimbal_quaternion(
-            vehicle_geopose: GeoPoseStamped,
+            geopose_stamped: GeoPoseStamped,
             gimbal_device_attitude_status: Optional[GimbalDeviceAttitudeStatus],
         ):
             if gimbal_device_attitude_status is None:
@@ -367,18 +322,20 @@ class AutopilotNode(RVizPublisherNode):
 
             assert gimbal_device_attitude_status is not None
 
-            compound_q = AutopilotNode.apply_vehicle_yaw(
-                vehicle_geopose.pose.orientation, gimbal_device_attitude_status.q
+            compound_q = _apply_vehicle_yaw(
+                geopose_stamped.pose.orientation, gimbal_device_attitude_status.q
             )
-            roll, pitch, yaw = AutopilotNode._euler_from_quaternion(compound_q)
+            roll, pitch, yaw = _euler_from_quaternion(compound_q)
 
             return compound_q
 
         return _gimbal_quaternion(
-            self.vehicle_geopose, self._gimbal_device_attitude_status
+            self.geopose_stamped, self.gimbal_device_attitude_status
         )
 
     @property
+    @ROS.max_delay_ms(500)
+    @ROS.publish(messaging.ROS_TOPIC_HOME_GEOPOINT, QoSPresetProfiles.SENSOR_DATA.value)
     def home_geopoint(self) -> Optional[GeoPointStamped]:
         """Home position as :class:`geographic_msgs.msg.GeoPointStamped` message
         or None if not available"""
@@ -394,64 +351,17 @@ class AutopilotNode(RVizPublisherNode):
                 ),
             )
 
-        return _home_geopoint(self._home_position)
+        return _home_geopoint(self.home_position)
 
-    # endregion computed attributes
-
-    # region public properties
     @property
-    def egm96_height(self) -> Optional[Float32]:
-        """EGM96 geoid height
-
-        Needed by implementing classes to generate vehicle
-        :class:`geographic_msgs.msg.GeoPoseStamped` and
-        :class:`mavros_msgs.msg.Altitude` messages
-        """
-        return self.__egm96_height
-
-    @egm96_height.setter
-    def egm96_height(self, value: Optional[Float32]) -> None:
-        self.__egm96_height = value
-
-    # endregion public properties
-
-    # region ROS subscriber callbacks
-
-    def __egm96_height_callback(self, msg: Float32) -> None:
-        """Handles ellipsoid height message"""
-        self.__egm96_height = msg
-
-    # endregion ROS subscriber callbacks
-
-    # region publish hooks
-    def publish_vehicle_geopose(self) -> None:
-        """Publishes vehicle :class:`geographic_msgs.msg.GeoPoseStamped`"""
-
-        @enforce_types(self.get_logger().warn, "Skipping publishing vehicle GeoPose")
-        def _publish_vehicle_geopose(vehicle_geopose: GeoPoseStamped):
-            self.__vehicle_geopose_pub.publish(vehicle_geopose)
-
-        _publish_vehicle_geopose(self.vehicle_geopose)
-
-    def publish_gimbal_quaternion(self) -> None:
-        """Publishes gimbal :class:`geometry_msgs.msg.Quaternion` orientation"""
-
-        # TODO: NED or ENU? ROS convention is ENU but current implementation is NED?
-        @enforce_types(self.get_logger().warn, "Skipping publishing gimbal Quaternion")
-        def _publish_gimbal_quaternion(gimbal_quaternion: Quaternion):
-            self.__gimbal_quaternion_pub.publish(gimbal_quaternion)
-
-        _publish_gimbal_quaternion(self.gimbal_quaternion)
-
-    def publish_home_geopoint(self) -> None:
-        """Publishes home :class:`.geographic_msgs.msg.GeoPointStamped`"""
+    def _altitude_local(self) -> Optional[float]:
+        """Returns z coordinate from :class:`sensor_msgs.msg.PoseStamped` message
+        or None if not available"""
 
         @enforce_types(
-            self.get_logger().warn, "Skipping publishing home GeoPointStamped"
+            self.get_logger().warn, "Cannot determine vehicle local altitude"
         )
-        def _publish_home_geopoint(home_geopoint: GeoPointStamped):
-            self.__home_geopoint_pub.publish(home_geopoint)
+        def _altitude_local(pose_stamped: PoseStamped):
+            return pose_stamped.pose.position.z
 
-        _publish_home_geopoint(self.home_geopoint)
-
-    # endregion publish hooks
+        return _altitude_local(self.pose_stamped)

--- a/gisnav/gisnav/nodes/autopilot_node.py
+++ b/gisnav/gisnav/nodes/autopilot_node.py
@@ -257,7 +257,7 @@ class AutopilotNode(RVizPublisherNode):
                 header=messaging.create_header("base_link"),
                 amsl=vehicle_altitude_amsl,
                 local=local,  # TODO: home altitude ok?
-                relative=-local,
+                relative=-local,  # TODO: check sign
                 terrain=vehicle_altitude_terrain,
                 bottom_clearance=np.nan,
             )
@@ -382,7 +382,7 @@ class AutopilotNode(RVizPublisherNode):
         or None if not available"""
 
         @enforce_types(self.get_logger().warn, "Cannot determine home GeoPoint")
-        def _home_geopoint(home_position: GeoPoint):
+        def _home_geopoint(home_position: HomePosition):
             return GeoPointStamped(
                 header=messaging.create_header("base_link"),
                 position=GeoPoint(

--- a/gisnav/gisnav/nodes/autopilot_node.py
+++ b/gisnav/gisnav/nodes/autopilot_node.py
@@ -57,7 +57,7 @@ class AutopilotNode(RVizPublisherNode):
         # Subscribers
         # terrain_altitude and egm96_height properties intended to be used by
         # extending classes -> no name mangling
-        self.terrain_altitude = None
+        self.terrain_altitude: Optional[Altitude] = None
         self.__terrain_altitude_sub = self.create_subscription(
             Altitude,
             messaging.ROS_TOPIC_TERRAIN_ALTITUDE,
@@ -65,7 +65,7 @@ class AutopilotNode(RVizPublisherNode):
             QoSPresetProfiles.SENSOR_DATA.value,
         )
 
-        self.egm96_height = None
+        self.egm96_height: Optional[Float32] = None
         self.__egm96_height_sub = self.create_subscription(
             Float32,
             messaging.ROS_TOPIC_EGM96_HEIGHT,
@@ -73,28 +73,28 @@ class AutopilotNode(RVizPublisherNode):
             QoSPresetProfiles.SENSOR_DATA.value,
         )
 
-        self._vehicle_nav_sat_fix = None
+        self._vehicle_nav_sat_fix: Optional[NavSatFix] = None
         self._vehicle_nav_sat_fix_sub = self.create_subscription(
             NavSatFix,
             "/mavros/global_position/global",
             self._vehicle_nav_sat_fix_callback,
             QoSPresetProfiles.SENSOR_DATA.value,
         )
-        self._vehicle_pose_stamped = None
+        self._vehicle_pose_stamped: Optional[PoseStamped] = None
         self._vehicle_pose_stamped_sub = self.create_subscription(
             PoseStamped,
             "/mavros/local_position/pose",
             self._vehicle_pose_stamped_callback,
             QoSPresetProfiles.SENSOR_DATA.value,
         )
-        self._home_position = None
+        self._home_position: Optional[HomePosition] = None
         self._home_position_sub = self.create_subscription(
             HomePosition,
             "/mavros/home_position/home",
             self._home_position_callback,
             QoSPresetProfiles.SENSOR_DATA.value,
         )
-        self._gimbal_device_attitude_status = None
+        self._gimbal_device_attitude_status: Optional[GimbalDeviceAttitudeStatus] = None
         self._gimbal_device_attitude_status_sub = self.create_subscription(
             GimbalDeviceAttitudeStatus,
             "/mavros/gimbal_control/device/attitude_status",

--- a/gisnav/gisnav/nodes/autopilot_node.py
+++ b/gisnav/gisnav/nodes/autopilot_node.py
@@ -476,6 +476,8 @@ class AutopilotNode(RVizPublisherNode):
             self.get_logger().warn, "Skipping publishing home GeoPointStamped"
         )
         def _publish_home_geopoint(home_geopoint: GeoPointStamped):
-            self.__home_geopoint_pub.publish(self.home_geopoint)
+            self.__home_geopoint_pub.publish(home_geopoint)
+
+        _publish_home_geopoint(self.home_geopoint)
 
     # endregion publish hooks

--- a/gisnav/gisnav/nodes/autopilot_node.py
+++ b/gisnav/gisnav/nodes/autopilot_node.py
@@ -60,11 +60,11 @@ class AutopilotNode(RVizPublisherNode):
         """Altitude of terrain directly under vehicle, or None if unknown or too old"""
 
     @property
-    @ROS.max_delay_ms(_DELAY_NORMAL_MS)
+    # @ROS.max_delay_ms(_DELAY_NORMAL_MS)  # Float32 does not have header
     @ROS.subscribe(
         messaging.ROS_TOPIC_EGM96_HEIGHT, QoSPresetProfiles.SENSOR_DATA.value
     )
-    def egm96_height(self) -> Optional[Altitude]:
+    def egm96_height(self) -> Optional[Float32]:
         """
         Height in meters of EGM96 geoid at vehicle location, or None if unknown
         or too old

--- a/gisnav/gisnav/nodes/autopilot_node.py
+++ b/gisnav/gisnav/nodes/autopilot_node.py
@@ -365,9 +365,6 @@ class AutopilotNode(RVizPublisherNode):
 
             assert gimbal_device_attitude_status is not None
 
-            roll, pitch, yaw = AutopilotNode._euler_from_quaternion(
-                gimbal_device_attitude_status.q
-            )
             compound_q = AutopilotNode.apply_vehicle_yaw(
                 vehicle_geopose.pose.orientation, gimbal_device_attitude_status.q
             )

--- a/gisnav/gisnav/nodes/autopilot_node.py
+++ b/gisnav/gisnav/nodes/autopilot_node.py
@@ -175,30 +175,30 @@ class AutopilotNode(RVizPublisherNode):
     @ROS.publish(
         messaging.ROS_TOPIC_VEHICLE_ALTITUDE, QoSPresetProfiles.SENSOR_DATA.value
     )
-    def vehicle_altitude(self) -> Optional[Altitude]:
+    def altitude(self) -> Optional[Altitude]:
         """Altitude of vehicle, or None if unknown or too old"""
 
         @enforce_types(self.get_logger().warn, "Cannot determine vehicle altitude")
-        def _vehicle_altitude(
+        def _altitude(
             nav_sat_fix: NavSatFix,
             egm96_height: Float32,
             terrain_altitude: Altitude,
             altitude_local: Optional[float],
         ):
-            vehicle_altitude_amsl = nav_sat_fix.altitude - egm96_height.data
-            vehicle_altitude_terrain = vehicle_altitude_amsl - terrain_altitude.amsl
+            altitude_amsl = nav_sat_fix.altitude - egm96_height.data
+            altitude_terrain = altitude_amsl - terrain_altitude.amsl
             local = altitude_local if altitude_local is not None else np.nan
             altitude = Altitude(
                 header=messaging.create_header("base_link"),
-                amsl=vehicle_altitude_amsl,
+                amsl=altitude_amsl,
                 local=local,  # TODO: home altitude ok?
                 relative=-local,  # TODO: check sign
-                terrain=vehicle_altitude_terrain,
+                terrain=altitude_terrain,
                 bottom_clearance=np.nan,
             )
             return altitude
 
-        return _vehicle_altitude(
+        return _altitude(
             self.nav_sat_fix,
             self.egm96_height,
             self.terrain_altitude,

--- a/gisnav/gisnav/nodes/base/rviz_publisher_node.py
+++ b/gisnav/gisnav/nodes/base/rviz_publisher_node.py
@@ -30,12 +30,12 @@ class RVizPublisherNode(BaseNode):
         """
         super().__init__(name)
 
-        self._pose_stamped_publisher = self.create_publisher(
+        self.__pose_stamped_publisher = self.create_publisher(
             PoseStamped,
             self.ROS_TOPIC_POSE_STAMPED,
             QoSPresetProfiles.SYSTEM_DEFAULT.value,
         )
-        self._path_publisher = self.create_publisher(
+        self.__path_publisher = self.create_publisher(
             Path,
             self.ROS_TOPIC_PATH,
             QoSPresetProfiles.SYSTEM_DEFAULT.value,
@@ -49,7 +49,7 @@ class RVizPublisherNode(BaseNode):
         path.header.stamp = self.get_clock().now().to_msg()
         path.header.frame_id = "map"
         path.poses = list(self._pose_stamped_queue)
-        self._path_publisher.publish(path)
+        self.__path_publisher.publish(path)
 
     def publish_rviz(self, geopose_stamped: GeoPoseStamped, alt_agl: float) -> None:
         """
@@ -100,4 +100,4 @@ class RVizPublisherNode(BaseNode):
 
         assert len(self._pose_stamped_queue) > 0
         self._publish_path()
-        self._pose_stamped_publisher.publish(pose_stamped)
+        self.__pose_stamped_publisher.publish(pose_stamped)

--- a/gisnav/gisnav/nodes/bbox_node.py
+++ b/gisnav/gisnav/nodes/bbox_node.py
@@ -1,6 +1,6 @@
 """A node that publishes bounding box of field of view projected to ground
 from vehicle approximate location"""
-from typing import Optional
+from typing import Optional, Tuple
 
 import numpy as np
 from geographic_msgs.msg import BoundingBox, GeoPoint, GeoPointStamped, GeoPoseStamped
@@ -256,7 +256,7 @@ class BBoxNode(CameraSubscriberNode):
         @enforce_types(self.get_logger().warn, "Cannot generate mock map data")
         def _mock_map_data(
             camera_data: CameraData,
-            map_size_with_padding: Dim,
+            map_size_with_padding: Tuple[int, int],
             vehicle_altitude: Altitude,
         ):
             altitude_agl = vehicle_altitude.terrain

--- a/gisnav/gisnav/nodes/bbox_node.py
+++ b/gisnav/gisnav/nodes/bbox_node.py
@@ -166,7 +166,7 @@ class BBoxNode(CameraSubscriberNode):
 
         # No need to call _publish here:
         # Vehicle altitude changes do affect bbox estimate but _publish is
-        # already called in GeoPose callback Altitude message is only
+        # already called in GeoPose callback. Altitude message is only
         # subscribed to because it provides altitude AGL and AMSL unlike GeoPose
         # self._publish()
 
@@ -261,6 +261,7 @@ class BBoxNode(CameraSubscriberNode):
         ):
             altitude_agl = vehicle_altitude.terrain
             if altitude_agl < 0:
+                # TODO: make alt AGL separate decorated property that does validation,clean up from here
                 self.get_logger().warn(
                     f"Altitude AGL {altitude_agl} was negative, skipping mock map data."
                 )

--- a/gisnav/gisnav/nodes/bbox_node.py
+++ b/gisnav/gisnav/nodes/bbox_node.py
@@ -261,7 +261,6 @@ class BBoxNode(CameraSubscriberNode):
         ):
             altitude_agl = vehicle_altitude.terrain
             if altitude_agl < 0:
-                # TODO: make alt AGL separate decorated property that does validation,clean up from here
                 self.get_logger().warn(
                     f"Altitude AGL {altitude_agl} was negative, skipping mock map data."
                 )
@@ -320,20 +319,20 @@ class BBoxNode(CameraSubscriberNode):
                     f"{translation} were invalid: {e}."
                 ) from e
 
-            try:
-                mock_fixed_camera = FixedCamera(
-                    pose=pose,
-                    image_pair=mock_image_pair,
-                    terrain_altitude_amsl=terrain_altitude.amsl,
-                    terrain_altitude_ellipsoid=terrain_geopoint.position.altitude,
-                    home_position=home_geopoint.position,
-                    timestamp=usec,
-                )
-            except DataValueError:
-                self.get_logger().warn(
-                    "Could not create a valid mock projection of FOV."
-                )
-                return None
+            # try:
+            mock_fixed_camera = FixedCamera(
+                pose=pose,
+                image_pair=mock_image_pair,
+                terrain_altitude_amsl=terrain_altitude.amsl,
+                terrain_altitude_ellipsoid=terrain_geopoint.position.altitude,
+                home_position=home_geopoint.position,
+                timestamp=usec,
+            )
+            # except DataValueError:
+            #    self.get_logger().warn(
+            #        "Could not create a valid mock projection of FOV."
+            #    )
+            #    return None
 
             return mock_fixed_camera.fov.fov.to_crs("epsg:4326").center
 

--- a/gisnav/gisnav/nodes/messaging.py
+++ b/gisnav/gisnav/nodes/messaging.py
@@ -72,6 +72,7 @@ def create_header(frame_id: str = "") -> Header:
     :param frame_id: Header frame_id value
     :return: ROS message header
     """
+    # TODO: use rclpy clock to create stamp
     time_ns = time.time_ns()
     sec = int(time_ns / 1e9)
     nanosec = int(time_ns - (1e9 * sec))

--- a/gisnav/launch/params/bbox_node.yaml
+++ b/gisnav/launch/params/bbox_node.yaml
@@ -2,4 +2,3 @@ bbox_node:
   ros__parameters:
     gimbal_projection: True
     max_map_radius: 1000
-    export_projection: ''


### PR DESCRIPTION
Declutters checking for Nones and other types in node computed properties, subscribing and publishing to topics. Makes it easier to see what is coming into and leaving a Node, and what gets transformed.

This pull request applies changes to `AutopilotNode` and `BBoxNode` only, but will focus next on refactoring the other nodes.