### PR TITLE
Enforce arm64 builds for onboard targets

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -130,6 +130,25 @@ define run_middleware
 	fi
 endef
 
+# The empty argument check for some reason is not working in the compose_template.
+# So we will pass a dummy dependency as a dependency target instead of an empty
+# argument.
+.PHONY: $(addprefix build-dummy-dependency-, $(AUTOPILOTS))
+.PHONY: $(addprefix create-dummy-dependency-, $(AUTOPILOTS))
+.PHONY: $(addprefix up-dummy-dependency-, $(AUTOPILOTS))
+
+build-dummy-dependency-px4:
+
+create-dummy-dependency-px4:
+
+up-dummy-dependency-px4:
+
+build-dummy-dependency-ardupilot:
+
+create-dummy-dependency-ardupilot:
+
+up-dummy-dependency-ardupilot:
+
 # Define middleware targets
 $(eval $(call middleware_template,onboard-hil-middleware,-f docker-compose.yaml -f docker-compose.serial.yaml))
 $(eval $(call middleware_template,onboard-sitl-middleware,))
@@ -142,7 +161,7 @@ $(eval $(call compose_template,onboard-hil,onboard-hil-middleware,docker-compose
 $(eval $(call compose_template,onboard-sitl,offboard-sitl-middleware,docker-compose.arm64.yaml,mapserver torch-serve gisnav))
 
 # offboard SITL services: Gazebo simulation, QGC
-$(eval $(call compose_template,offboard-sitl,,,$$* qgc))
+$(eval $(call compose_template,offboard-sitl,dummy-dependency,,$$* qgc))
 
 # SITL testing services: Gazebo simulation, ROS middleware, mapserver, torch-serve, but excluding GISNav and QGC
 $(eval $(call compose_template,offboard-sitl-test,offboard-sitl-middleware,docker-compose.headless.yaml,$$* torch-serve mapserver))

--- a/docker/docker-compose.arm64.yaml
+++ b/docker/docker-compose.arm64.yaml
@@ -3,4 +3,26 @@ services:
   mapserver:
     build:
       args:
-        - DOCKER_TAG=latest-arm64
+        DOCKER_TAG: latest-arm64
+      platforms:
+        - linux/arm64
+
+  micro-ros-agent:
+    build:
+      platforms:
+        - linux/arm64
+
+  mavros:
+    build:
+      platforms:
+        - linux/arm64
+
+  gisnav:
+    build:
+      platforms:
+        - linux/arm64
+
+  torch-serve:
+    build:
+      platforms:
+        - linux/arm64

--- a/docker/docker-compose.arm64.yaml
+++ b/docker/docker-compose.arm64.yaml
@@ -1,28 +1,24 @@
+x-arm64: &arm64
+  build:
+    platforms:
+      - linux/arm64
+
 services:
   # User arm64 version of mapserver docker image (e.g. for Jetson Nano)
   mapserver:
+    <<: *arm64
     build:
       args:
         DOCKER_TAG: latest-arm64
-      platforms:
-        - linux/arm64
 
   micro-ros-agent:
-    build:
-      platforms:
-        - linux/arm64
+    <<: *arm64
 
   mavros:
-    build:
-      platforms:
-        - linux/arm64
+    <<: *arm64
 
   gisnav:
-    build:
-      platforms:
-        - linux/arm64
+    <<: *arm64
 
   torch-serve:
-    build:
-      platforms:
-        - linux/arm64
+    <<: *arm64

--- a/docker/docker-compose.headless.yaml
+++ b/docker/docker-compose.headless.yaml
@@ -2,8 +2,8 @@ services:
   # Sets Gazebo to run in headless mode
   px4:
     environment:
-      - HEADLESS=1
+      HEADLESS: 1
 
   ardupilot:
     environment:
-      - HEADLESS=1
+      HEADLESS: 1

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,10 +1,16 @@
 version: "3.4"
 
+# platforms is a sequence not a mapping so careful when merging
+# with something that defines its own platforms
 x-base: &base
   build:
     dockerfile: Dockerfile
+    platforms:
+      - "linux/amd64"
   network_mode: host
 
+# devices is a sequence not a mapping so careful when merging
+# with something that defines its own devices
 x-nvidia-gpu: &nvidia-gpu
   deploy:
     resources:
@@ -14,6 +20,8 @@ x-nvidia-gpu: &nvidia-gpu
             count: 1
             capabilities: [ gpu ]
 
+# volumes is a sequence not a mapping so careful when merging
+# with something that defines its own volumes
 x-x11: &x11
   environment:
     QT_X11_NO_MITSHM: 1
@@ -36,7 +44,10 @@ services:
     build:
       context: mapserver
       args:
-        - DOCKER_TAG=latest
+        DOCKER_TAG: latest
+      platforms:
+        - "linux/amd64"
+        - "linux/arm64"
     command: /usr/local/bin/start-server
 
   mapproxy:
@@ -44,22 +55,28 @@ services:
     build:
       context: mapproxy
       args:
-        - MAPPROXY_TILE_URL="https://<your-map-server-url>/tiles/%(z)s/%(y)s/%(x)s"
-        - CONFIG_FILE=yaml/mapproxy.yaml
-        - HOST=localhost
-        - PORT=80
+        MAPPROXY_TILE_URL: "https://<your-map-server-url>/tiles/%(z)s/%(y)s/%(x)s"
+        CONFIG_FILE: yaml/mapproxy.yaml
+        HOST: localhost
+        PORT: 80
     command: mapproxy-util serve-develop -b $HOST:$PORT $HOME/$(basename $CONFIG_FILE)
 
   micro-ros-agent:
     <<: [*base, *ros]
     build:
       context: micro-ros-agent
+      platforms:
+        - "linux/amd64"
+        - "linux/arm64"
     command: udp4 -p 8888
 
   mavros:
     <<: [*base, *ros]
     build:
       context: mavros
+      platforms:
+        - "linux/amd64"
+        - "linux/arm64"
     command: ros2 run mavros mavros_node --ros-args --param fcu_url:=udp://:14540@localhost:14557
 
   qgc:
@@ -67,6 +84,7 @@ services:
     build:
       context: qgc
     volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:ro
       - /dev/shm:/dev/shm
       - /dev/dri:/dev/dri
     privileged: true
@@ -79,10 +97,14 @@ services:
       dockerfile: docker/gisnav/Dockerfile
       args:
         ROS_VERSION: humble
+      platforms:
+        - "linux/amd64"
+        - "linux/arm64"
     image: gisnav  # used by GitHub upload_gisnav_image CI workflow
     environment:
       FASTRTPS_DEFAULT_PROFILES_FILE: /opt/colcon_ws/src/gisnav/docker/gisnav/disable_shared_memory.xml
     volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:ro
       - /dev/dri:/dev/dri
     command: ros2 launch gisnav px4.launch.py
 
@@ -91,6 +113,7 @@ services:
     build:
       context: px4
     volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:ro
       - /dev/shm:/dev/shm
       - /dev/dri:/dev/dri
     command: make px4_sitl gazebo-classic_typhoon_h480__ksql_airport
@@ -100,6 +123,7 @@ services:
     build:
       context: ardupilot
     volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix:ro
       - /dev/shm:/dev/shm
       - /dev/dri:/dev/dri
     privileged: True
@@ -110,7 +134,10 @@ services:
     build:
       context: torch-serve
       args:
-        - BASE_IMAGE=pytorch/torchserve:latest-gpu
+        BASE_IMAGE: pytorch/torchserve:latest-gpu
+      platforms:
+        - "linux/amd64"
+        - "linux/arm64"
 
   # Note: build context is repository root
   rviz:
@@ -124,6 +151,6 @@ services:
     image: willfarrell/autoheal
     restart: always
     environment:
-      - AUTOHEAL_CONTAINER_LABEL=all
+      AUTOHEAL_CONTAINER_LABEL: all
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -5,8 +5,8 @@ version: "3.4"
 x-base: &base
   build:
     dockerfile: Dockerfile
-    platforms:
-      - "linux/amd64"
+    #platforms:
+    #  - "linux/amd64"
   network_mode: host
 
 # devices is a sequence not a mapping so careful when merging
@@ -45,9 +45,9 @@ services:
       context: mapserver
       args:
         DOCKER_TAG: latest
-      platforms:
-        - "linux/amd64"
-        - "linux/arm64"
+      #platforms:
+      #  - "linux/amd64"
+      #  - "linux/arm64"
     command: /usr/local/bin/start-server
 
   mapproxy:
@@ -65,18 +65,18 @@ services:
     <<: [*base, *ros]
     build:
       context: micro-ros-agent
-      platforms:
-        - "linux/amd64"
-        - "linux/arm64"
+      #platforms:
+      #  - "linux/amd64"
+      #  - "linux/arm64"
     command: udp4 -p 8888
 
   mavros:
     <<: [*base, *ros]
     build:
       context: mavros
-      platforms:
-        - "linux/amd64"
-        - "linux/arm64"
+      #platforms:
+      #  - "linux/amd64"
+      #  - "linux/arm64"
     command: ros2 run mavros mavros_node --ros-args --param fcu_url:=udp://:14540@localhost:14557
 
   qgc:
@@ -97,9 +97,9 @@ services:
       dockerfile: docker/gisnav/Dockerfile
       args:
         ROS_VERSION: humble
-      platforms:
-        - "linux/amd64"
-        - "linux/arm64"
+      #platforms:
+      #  - "linux/amd64"
+      #  - "linux/arm64"
     image: gisnav  # used by GitHub upload_gisnav_image CI workflow
     environment:
       FASTRTPS_DEFAULT_PROFILES_FILE: /opt/colcon_ws/src/gisnav/docker/gisnav/disable_shared_memory.xml
@@ -135,9 +135,9 @@ services:
       context: torch-serve
       args:
         BASE_IMAGE: pytorch/torchserve:latest-gpu
-      platforms:
-        - "linux/amd64"
-        - "linux/arm64"
+      #platforms:
+      #  - "linux/amd64"
+      #  - "linux/arm64"
 
   # Note: build context is repository root
   rviz:

--- a/docker/gisnav/Dockerfile
+++ b/docker/gisnav/Dockerfile
@@ -35,9 +35,11 @@ RUN apt-get -y install ros-${ROS_VERSION}-mavros ros-${ROS_VERSION}-mavros-extra
     bash install_geographiclib_datasets.sh
 
 # Custom ROS messages (px4_msgs and mavros mavlink gimbal protocl v2 support)
+# sed edits px4_msgs CMakeLists.txt so that only SensorGps message is built
 RUN cd /opt/colcon_ws/src/ && \
     git clone --branch release/1.14  \
       https://github.com/px4/px4_msgs.git && \
+    sed -i 's/\*\.msg/SensorGps.msg/g' px4_msgs/CMakeLists.txt && \
     git clone --branch gimbal-protocol-v2-plugin \
       https://github.com/adinkra-labs/mavros_feature_gimbal-protocol-v2-plugin.git mavros && \
     sed -i 's/tf2_eigen.hpp/tf2_eigen.h/g'  \

--- a/docker/micro-ros-agent/Dockerfile
+++ b/docker/micro-ros-agent/Dockerfile
@@ -2,10 +2,12 @@ FROM microros/micro-ros-agent:foxy
 
 LABEL maintainer="Harri Makelin <hmakelin@protonmail.com>"
 
+# sed edits px4_msgs CMakeLists.txt so that only SensorGps message is built
 RUN cd /uros_ws && \
     mkdir src && \
     cd src && \
     git clone https://github.com/px4/px4_msgs.git && \
+    sed -i 's/\*\.msg/SensorGps.msg/g' px4_msgs/CMakeLists.txt && \
     cd .. && \
     . /opt/ros/foxy/setup.sh && \
     colcon build --packages-select px4_msgs


### PR DESCRIPTION
Makes it possible to use existing instructions and commands to cross compile arm64 images for onboard use on development machines and CI runners that are amd64 based (building on Jetson Nano is very slow).

Other:
- `docker/Makefile` bug fixes
- Decrease px4_msgs build time in docker images by only building the `SensorGps` message and not other messages which are not used