### PR TITLE
Free up space on GitHub runner

### DIFF
--- a/.github/workflows/push_gisnav_images.yml
+++ b/.github/workflows/push_gisnav_images.yml
@@ -44,7 +44,12 @@ jobs:
           docker buildx create --use
 
       # TODO: try to use docker-compose.yaml file to avoid having to specify redundant build args here
+      # Build arm64 and amd64 images separately to be more efficient with disk
+      # space on GitHub runner
       - name: Build and push GISNav multi-arch Docker images
         run: |
           cd colcon_ws/src/gisnav
-          docker buildx build --build-arg ROS_VERSION=humble --push --platform linux/amd64,linux/arm64 -f docker/gisnav/Dockerfile -t ghcr.io/hmakelin/gisnav:${TAG:-latest} .
+          docker buildx build --build-arg ROS_VERSION=humble --push --platform linux/amd64 -f docker/gisnav/Dockerfile -t ghcr.io/hmakelin/gisnav:${TAG:-latest} .
+          docker rmi ghcr.io/hmakelin/gisnav:${TAG:-latest}
+          docker system prune --force
+          docker buildx build --build-arg ROS_VERSION=humble --push --platform linux/arm64 -f docker/gisnav/Dockerfile -t ghcr.io/hmakelin/gisnav:${TAG:-latest} .

--- a/.github/workflows/push_gisnav_images.yml
+++ b/.github/workflows/push_gisnav_images.yml
@@ -44,12 +44,13 @@ jobs:
           docker buildx create --use
 
       # TODO: try to use docker-compose.yaml file to avoid having to specify redundant build args here
-      # Build arm64 and amd64 images separately to be more efficient with disk
-      # space on GitHub runner
+      # Remove some directories and apt dependencies to free up disk space
+      # for the multi-arch image
       - name: Build and push GISNav multi-arch Docker images
         run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           cd colcon_ws/src/gisnav
-          docker buildx build --build-arg ROS_VERSION=humble --push --platform linux/amd64 -f docker/gisnav/Dockerfile -t ghcr.io/hmakelin/gisnav:${TAG:-latest} .
-          docker rmi ghcr.io/hmakelin/gisnav:${TAG:-latest}
-          docker system prune --force
-          docker buildx build --build-arg ROS_VERSION=humble --push --platform linux/arm64 -f docker/gisnav/Dockerfile -t ghcr.io/hmakelin/gisnav:${TAG:-latest} .
+          docker buildx build --build-arg ROS_VERSION=humble --push --platform linux/amd64,linux/arm64 -f docker/gisnav/Dockerfile -t ghcr.io/hmakelin/gisnav:${TAG:-latest} .


### PR DESCRIPTION
We need to free up space on the runner for the multi-arch images (possibly up to 20 GB)