### PR TITLE
Include pretrained weights in image

### DIFF
--- a/docker/mavros/Dockerfile
+++ b/docker/mavros/Dockerfile
@@ -97,6 +97,9 @@ COPY docker/mavros/gisnav/entrypoint.sh /
 
 RUN chmod +x /entrypoint.sh
 
+# Download LoFTR pretrained weights
+RUN python3 -c  "from kornia.feature import LoFTR; LoFTR(pretrained='outdoor')"
+
 ENTRYPOINT ["/entrypoint.sh"]
 
 # TODO: proper health check - check that public facing topics are publishing

--- a/docker/mavros/Dockerfile
+++ b/docker/mavros/Dockerfile
@@ -98,7 +98,7 @@ COPY docker/mavros/gisnav/entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 
 # Download LoFTR pretrained weights
-RUN python3 -c  "from kornia.feature import LoFTR; LoFTR(pretrained='outdoor')"
+RUN python3 -c "from kornia.feature import LoFTR; LoFTR(pretrained='outdoor')"
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
Makes container startup significantly faster on first run as pretrained weights are already included in the image.