### PR TITLE
Enable visual odometry

### DIFF
--- a/docker/px4/6011_typhoon_h480
+++ b/docker/px4/6011_typhoon_h480
@@ -16,8 +16,8 @@ param set-default EKF2_REQ_VDRIFT 1.5   # max value
 param set-default EKF2_REQ_SACC 5.0     # max value
 param set-default EKF2_HEAD_NOISE 1.0   # max value
 param set-default SENS_GPS_MASK 7
-param set-default EKF2_GPS_CTRL 8       # lon/lat, alt, 3D vel, heading
-param set-default EKF2_GPS_CHECK 0
+param set-default EKF2_GPS_CTRL 15      # max: lon/lat, alt, 3D vel, heading
+#param set-default EKF2_GPS_CHECK 0
 
 # Secondary GPS (GISNav) at GPS 2 serial port via NMEA
 # https://docs.px4.io/v1.14/en/hardware/serial_port_mapping.html#default-px4board

--- a/gisnav/gisnav/_transformations.py
+++ b/gisnav/gisnav/_transformations.py
@@ -14,6 +14,7 @@ from geometry_msgs.msg import (
     PoseWithCovarianceStamped,
     Quaternion,
     TransformStamped,
+    TwistWithCovarianceStamped,
 )
 from pyproj import Proj, transform
 from rclpy.node import Node
@@ -411,3 +412,82 @@ def enu_to_ecef_matrix(lon: float, lat: float) -> np.ndarray:
         ]
     )
     return R
+
+
+def poses_to_twist(
+    pose2: PoseWithCovarianceStamped, pose1: PoseStamped
+) -> TwistWithCovarianceStamped:
+    """pose2 is newer pose with covariances, pose1 is older pose (identity pose in
+    VO)
+    """
+    # Time step between poses
+    t2, t1 = usec_from_header(pose2.header), usec_from_header(pose1.header)
+
+    time_step = (t2 - t1) / 1e6  # seconds
+
+    # Calculate linear velocities
+    dx = pose2.pose.pose.position.x - pose1.pose.position.x
+    dy = pose2.pose.pose.position.y - pose1.pose.position.y
+    dz = pose2.pose.pose.position.z - pose1.pose.position.z
+
+    # Calculate angular velocities using quaternion differences
+    q1 = [
+        pose1.pose.orientation.x,
+        pose1.pose.orientation.y,
+        pose1.pose.orientation.z,
+        pose1.pose.orientation.w,
+    ]
+    q2 = [
+        pose2.pose.pose.orientation.x,
+        pose2.pose.pose.orientation.y,
+        pose2.pose.pose.orientation.z,
+        pose2.pose.pose.orientation.w,
+    ]
+    r1 = tf_transformations.quaternion_matrix(q1)
+    r2 = tf_transformations.quaternion_matrix(q2)
+    r_diff = r2 * r1.T
+
+    # TODO do not convert to matrices above, just use quaternions
+    q_diff = tf_transformations.quaternion_from_matrix(r_diff)
+
+    # Converting quaternion to rotation vector (axis-angle)
+    angle = 2 * np.arccos(q_diff[3])  # Compute the rotation angle
+    axis = q_diff[:3] / np.sin(angle / 2)  # Normalize the axis
+    rotation_vector = angle * axis  # Multiply angle by the normalized axis
+
+    ang_vel = rotation_vector / time_step
+
+    # Create TwistStamped message
+    twist = TwistWithCovarianceStamped()
+    twist.header.stamp = pose2.header.stamp
+    twist.header.frame_id = pose2.header.frame_id
+    twist.twist.twist.linear.x = dx / time_step
+    twist.twist.twist.linear.y = dy / time_step
+    twist.twist.twist.linear.z = dz / time_step
+    twist.twist.twist.angular.x = ang_vel[0]
+    twist.twist.twist.angular.y = ang_vel[1]
+    twist.twist.twist.angular.z = ang_vel[2]
+
+    twist.twist.covariance = pose2.pose.covariance  # todo: could make these smaller?
+
+    return twist
+
+
+def create_identity_pose_stamped(x, y, z):
+    pose_stamped = PoseStamped()
+
+    pose_stamped.header.stamp = rclpy.time.Time().to_msg()
+    pose_stamped.header.frame_id = "camera_optical"
+
+    # Set the position coordinates
+    pose_stamped.pose.position.x = x
+    pose_stamped.pose.position.y = y
+    pose_stamped.pose.position.z = z
+
+    # Set the orientation to identity (no rotation)
+    pose_stamped.pose.orientation.x = 0.0
+    pose_stamped.pose.orientation.y = 0.0
+    pose_stamped.pose.orientation.z = 0.0
+    pose_stamped.pose.orientation.w = 1.0
+
+    return pose_stamped

--- a/gisnav/gisnav/_transformations.py
+++ b/gisnav/gisnav/_transformations.py
@@ -443,12 +443,10 @@ def poses_to_twist(
         pose2.pose.pose.orientation.z,
         pose2.pose.pose.orientation.w,
     ]
-    r1 = tf_transformations.quaternion_matrix(q1)
-    r2 = tf_transformations.quaternion_matrix(q2)
-    r_diff = r2 * r1.T
 
-    # TODO do not convert to matrices above, just use quaternions
-    q_diff = tf_transformations.quaternion_from_matrix(r_diff)
+    q_diff = tf_transformations.quaternion_multiply(
+        q2, tf_transformations.quaternion_inverse(q1)
+    )
 
     # Converting quaternion to rotation vector (axis-angle)
     angle = 2 * np.arccos(q_diff[3])  # Compute the rotation angle

--- a/gisnav/gisnav/constants.py
+++ b/gisnav/gisnav/constants.py
@@ -64,9 +64,9 @@ ROS_TOPIC_RELATIVE_POSE: Final = "~/pose"
 :attr:`.StereoNode.pose`.
 
 """
-ROS_TOPIC_RELATIVE_QUERY_POSE: Final = "~/vo/pose"
+ROS_TOPIC_RELATIVE_QUERY_TWIST: Final = "~/vo/twist"
 """Relative :term:`topic` into which :class:`.StereoNode` publishes
-:attr:`.StereoNode.camera_optical_pose_in_query_frame`.
+:attr:`.StereoNode.camera_optical_twist_in_query_frame`.
 """
 
 MAVROS_TOPIC_TIME_REFERENCE: Final = "/mavros/time_reference"

--- a/gisnav/gisnav/core/pose_node.py
+++ b/gisnav/gisnav/core/pose_node.py
@@ -336,9 +336,10 @@ class PoseNode(Node):
         x, y, z = (
             scaling * 320.0,
             scaling * 180.0,
-            scaling * 205.0,
+            scaling * -205.0,
         )  # todo do not hard code
         previous_pose = tf_.create_identity_pose_stamped(x, y, z)
+        previous_pose.header = msg.reference.header
         current_pose = self._get_pose(msg)
         if current_pose is not None:
             return tf_.poses_to_twist(current_pose, previous_pose)

--- a/gisnav/gisnav/core/pose_node.py
+++ b/gisnav/gisnav/core/pose_node.py
@@ -327,7 +327,17 @@ class PoseNode(Node):
         self, msg: MonocularStereoImage
     ) -> Optional[TwistWithCovarianceStamped]:
         """Camera pose in visual odometry world frame (i.e. previous query frame)"""
-        x, y, z = 320.0, 180.0, 205.0  # todo do not hard code
+        scaling = self._scaling_buffer.interpolate(
+            tf_.usec_from_header(msg.query.header)
+        )
+        if scaling is None:
+            return None
+
+        x, y, z = (
+            scaling * 320.0,
+            scaling * 180.0,
+            scaling * 205.0,
+        )  # todo do not hard code
         previous_pose = tf_.create_identity_pose_stamped(x, y, z)
         current_pose = self._get_pose(msg)
         if current_pose is not None:

--- a/gisnav/gisnav/core/stereo_node.py
+++ b/gisnav/gisnav/core/stereo_node.py
@@ -71,7 +71,7 @@ class StereoNode(Node):
         # setup publisher to pass launch test without image callback being
         # triggered
         self.pose_image
-        # self.twist_image  # todo re-enable once scaling is solved
+        self.twist_image
 
         # Initialize the transform broadcaster and listener
         self._tf_buffer = tf2_ros.Buffer()
@@ -99,8 +99,7 @@ class StereoNode(Node):
         """Callback for :attr:`.image` message"""
         self.pose_image  # publish rotated and cropped orthoimage stack
 
-        # TODO: re-enable once proper scaling is implemented for VO
-        # self.twist_image  # publish two subsequent images for VO
+        self.twist_image  # publish two subsequent images for VO
 
         # TODO this is brittle - nothing is enforcing that this is assigned after
         #  publishing stereo_image

--- a/gisnav/launch/params/ekf_node.yaml
+++ b/gisnav/launch/params/ekf_node.yaml
@@ -29,12 +29,13 @@ robot_localization:
       # Fuse absolute pose estimated from map rasters
       pose0: "/gisnav/pose_node/pose"
       pose0_config: [true, true, true,     # Position XYZ
-                     true, true, true,     # Orientation (roll, pitch, yaw)
+                     false, false, false, #true, true, true,     # Orientation (roll, pitch, yaw)
                      false, false, false,  # Velocity XYZ
                      false, false, false,  # Angular rates XYZ
                      false, false, false]  # Accelerations XYZ
 
       # Fuse smooth relative pose estimated via VO differentially as velocity
+      # - better than a lagging velocity from pose0
       #pose1: "/gisnav/pose_node/vo/pose"
       #pose1_differential: true
       #pose1_config: [true, true, true,     # Position XYZ
@@ -43,13 +44,13 @@ robot_localization:
       #               false, false, false,  # Angular rates XYZ
       #               false, false, false]  # Accelerations XYZ
 
-      #pose1: "/gisnav/pose_node/vo/pose"
-      #pose1_differential: true
-      #pose1_config: [false, false, false,  # Position XYZ
-      #               false, false, false,  # Orientation (roll, pitch, yaw)
-      #               true, true, true,     # Velocity XYZ
-      #               true, true, true,     # Angular rates XYZ
-      #               false, false, false]  # Accelerations XYZ
+      pose1: "/gisnav/pose_node/vo/pose"
+      pose1_differential: true
+      pose1_config: [false, false, false,  # Position XYZ
+                     false, false, false,  # Orientation (roll, pitch, yaw)
+                     true, true, true,     # Velocity XYZ
+                     true, true, true,     # Angular rates XYZ
+                     false, false, false]  # Accelerations XYZ
 
       #debug: true
       #debug_out_file: "/home/hmakelin/robot_localization_debug.txt"

--- a/gisnav/launch/params/ekf_node.yaml
+++ b/gisnav/launch/params/ekf_node.yaml
@@ -44,13 +44,12 @@ robot_localization:
       #               false, false, false,  # Angular rates XYZ
       #               false, false, false]  # Accelerations XYZ
 
-      pose1: "/gisnav/pose_node/vo/pose"
-      pose1_differential: true
-      pose1_config: [false, false, false,  # Position XYZ
-                     false, false, false,  # Orientation (roll, pitch, yaw)
-                     true, true, true,     # Velocity XYZ
-                     true, true, true,     # Angular rates XYZ
-                     false, false, false]  # Accelerations XYZ
+      twist1: "/gisnav/pose_node/vo/twist"
+      twist1_config: [false, false, false,  # Position XYZ
+                      false, false, false,  # Orientation (roll, pitch, yaw)
+                      true, true, true,     # Velocity XYZ
+                      true, true, true,     # Angular rates XYZ
+                      false, false, false]  # Accelerations XYZ
 
       #debug: true
       #debug_out_file: "/home/hmakelin/robot_localization_debug.txt"

--- a/gisnav/package.xml
+++ b/gisnav/package.xml
@@ -46,6 +46,7 @@
   <depend>python3-setuptools</depend> <!-- setuptools is build dependency only? -->
   <depend>python3-shapely</depend>
   <depend>python3-serial</depend>
+  <depend>python3-scipy</depend>
   <!-- <depend>python3-owslib</depend> not found by rosdep, in setup.py instead -->
 
   <!-- need these to install things from setup.py -->

--- a/gisnav/setup.py
+++ b/gisnav/setup.py
@@ -117,7 +117,6 @@ setup(
         "torch>=2.1.0",
         "kornia==0.7.2",  # 0.7.2 for LightGlue and DISK
         "transforms3d",  # tf_transformations needs this
-        "scipy",
     ],
     tests_require=["pytest"],
     extras_require={

--- a/gisnav/setup.py
+++ b/gisnav/setup.py
@@ -117,6 +117,7 @@ setup(
         "torch>=2.1.0",
         "kornia==0.7.2",  # 0.7.2 for LightGlue and DISK
         "transforms3d",  # tf_transformations needs this
+        "scipy",
     ],
     tests_require=["pytest"],
     extras_require={


### PR DESCRIPTION
Speed variance is off, but disabling fusion of orientation by default in this PR makes the demo more stable for now. RViz will not correctly display orientation from Odometry message.