### PR TITLE
Enable precommit inside gisnav container

### DIFF
--- a/debian/gisnav/Makefile
+++ b/debian/gisnav/Makefile
@@ -79,6 +79,10 @@ $(BUILD_DIR)/etc/systemd:
 	@cp -r etc/systemd/ $@
 
 $(BUILD_DIR)/etc/gisnav: $(BUILD_DIR)/etc/gisnav/ros $(BUILD_DIR)/etc/gisnav/docker $(BUILD_DIR)/etc/gisnav/docs
+	@dest=debian/gisnav/$@ && \
+	mkdir -p $@ && \
+	touch $(BUILD_DIR)/COLCON_IGNORE && \
+	cd ${REPO_ROOT_PATH}; rsync -av --exclude-from='.gitignore' Makefile .pre-commit-config.yaml LICENSE.md README.md pyproject.toml $$dest
 
 $(BUILD_DIR)/etc/gisnav/ros:
 	@dest=debian/gisnav/$@ && \

--- a/docker/mavros/Dockerfile
+++ b/docker/mavros/Dockerfile
@@ -77,6 +77,7 @@ COPY ros/gisnav/package.xml gisnav/ros/gisnav/package.xml
 # the setup.py python dependencies later.
 RUN cd gisnav/ros/gisnav && \
     rosdep update && \
+    apt-get update && \
     rosdep install --from-paths . -y -r --ignore-src && \
     rm -rf /var/lib/apt/lists/* && \
     apt clean
@@ -125,5 +126,10 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     && nvm use 20 \
     && cd docs/vitepress \
     && npm install
+
+COPY Makefile .pre-commit-config.yaml LICENSE.md README.md pyproject.toml /opt/colcon_ws/src/gisnav/
+
+# .git needed to make pre-commit work -> initialize a blank repo
+RUN git init
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/ros/gisnav/Makefile
+++ b/ros/gisnav/Makefile
@@ -17,7 +17,8 @@ test-launch:
 test-unit:
 	@python3 -m unittest discover -s $(MAKEFILE_DIR)test/unit -p "test_*.py"
 
+# TODO: move test-static to same directory as .pre-commit-config.yaml
 .PHONY: test-static
 test-static:
-	@pre-commit run --all-files --config $(MAKEFILE_DIR).pre-commit-config.yaml
+	@pre-commit run --all-files --config $(MAKEFILE_DIR)/../../.pre-commit-config.yaml
 # test end


### PR DESCRIPTION
Initialize a blank .git repo inside the gisnav service container to enable pre-commit.