### PR TITLE
Fix autodocsumm version

### DIFF
--- a/ros/gisnav/setup.py
+++ b/ros/gisnav/setup.py
@@ -124,7 +124,7 @@ setup(
         "nmea_node": ["pynmea2"],
         "dev": [
             "aiohttp",
-            "autodocsumm",
+            "autodocsumm!=0.2.13",
             "coverage",
             "docutils>=0.17",
             "jupyter",


### PR DESCRIPTION
Documentation does not build inside container with latest (0.2.13/Aug 5) version of `autodocsumm`.