### PR TITLE
Fix getting started build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ everything will take a long time):
 >   volume and will be slow to start up (on first run).
 
 ```bash
-gnc create --build px4 gisnav
+gnc build px4 gisnav --with-dependencies
+gnc create px4 gisnav
 gnc start px4 gisnav && gnc stop autoheal
 ```
 

--- a/docs/vitepress/docs/gisnav-cli.md
+++ b/docs/vitepress/docs/gisnav-cli.md
@@ -26,13 +26,15 @@ If you are experienced with `docker compose`, using `gnc` should be intuitive. A
 Prepare services on `localhost`:
 
 ```bash
-gnc create --build gisnav px4
+gnc build px4 gisnav --with-dependencies
+gnc create gisnav px4
 ```
 
 Prepare `gisnav` on remote host `jetsonnano.local`:
 
 ```bash
-gnc create --build gisnav@jetsonnano.local
+gnc build gisnav@jetsonnano.local --with-dependencies
+gnc create gisnav@jetsonnano.local
 ```
 
 Start both simulation and `gisnav` services on `localhost`:


### PR DESCRIPTION
Need `--with-dependencies` option to build all dependencies for px4 and gisnav